### PR TITLE
fix: mount pb_migrations in the correct directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    env_file: .env
   grimoire:
     image: goniszewski/grimoire:latest
     container_name: grimoire


### PR DESCRIPTION
This will now run automatic migrations when mounted.

Fixes #26.