### PR TITLE
chore: clean up apt index files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
-RUN apt-get update && apt-get install -y python3 python3-pip
+RUN apt-get update && apt-get install -y python3 python3-pip && rm -rf /var/lib/apt/lists/*
 COPY . /app
 WORKDIR /app
 


### PR DESCRIPTION
Make sure no unnecessary apt files been packaged into the image, which will make the image unnecessarily larger.