### PR TITLE
Fix PocketBaseUrl in Config.ts

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,9 +7,9 @@ const config = {
 	IS_DEV: import.meta.env.DEV,
 	ORIGIN: env.PUBLIC_ORIGIN || getProcessEnvValue('PUBLIC_ORIGIN') || 'http://localhost:5173',
 	POCKETBASE_URL:
-		env.PUBLIC_POCKETBASE_URL || getProcessEnvValue('PUBLIC_POCKETBASE_URL') || import.meta.env.DEV
+		env.PUBLIC_POCKETBASE_URL || getProcessEnvValue('PUBLIC_POCKETBASE_URL') || (import.meta.env.DEV
 			? 'http://localhost:8090'
-			: 'http://pocketbase',
+			: 'http://pocketbase'),
 	HTTPS_ONLY:
 		(env.PUBLIC_HTTPS_ONLY || getProcessEnvValue('PUBLIC_HTTPS_ONLY')) === 'true' || false,
 	SIGNUP_DISABLED:


### PR DESCRIPTION
This PR fixes an issue where the POCKETBASE_URL is evaluated incorrectly due to the ternary added for dev config. Currently it will evaluate the POCKETBASE_URL to either localhost or pocketbase and never to the actual value provided by env.PUBLIC_POCKETBASE_URL || getProcessEnvValue('PUBLIC_POCKETBASE_URL') 