### PR TITLE
Reduce Image Size and add new Alpine based Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN bun --bun run build
 
 FROM base AS release
 
-RUN adduser --disabled-password --gecos '' grimoire
+RUN adduser --disabled-password --gecos '' --uid 10001 grimoire
 RUN mkdir -p /app/data && chown -R grimoire:grimoire /app/data && chmod 766 /app/data
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM --platform=$BUILDPLATFORM oven/bun:1.2 AS base
-
-FROM base AS builder
 LABEL maintainer="Grimoire Developers <contact@grimoire.pro>"
 LABEL description="Bookmark manager for the wizards"
 LABEL org.opencontainers.image.source="https://github.com/goniszewski/grimoire"
+RUN adduser --disabled-password --gecos '' --uid 10001 grimoire
+
+FROM base AS builder
 
 RUN mkdir -p /etc/s6-overlay/s6-rc.d/grimoire /etc/s6-overlay/s6-rc.d/user/contents.d /app/data
 
@@ -51,7 +52,6 @@ ENV S6_KEEP_ENV=1 \
 
 RUN bun i -g svelte-kit@latest
 
-RUN adduser --disabled-password --gecos '' grimoire
 RUN mkdir -p /app/data && chown -R grimoire:grimoire /app/data && chmod 766 /app/data
 WORKDIR /app
 
@@ -75,7 +75,6 @@ RUN bun --bun run build
 
 FROM base AS release
 
-RUN adduser --disabled-password --gecos '' --uid 10001 grimoire
 RUN mkdir -p /app/data && chown -R grimoire:grimoire /app/data && chmod 766 /app/data
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,37 @@
-FROM --platform=$BUILDPLATFORM oven/bun:1.2 AS builder
+FROM --platform=$BUILDPLATFORM oven/bun:1.2 AS base
+
+FROM base AS builder
 LABEL maintainer="Grimoire Developers <contact@grimoire.pro>"
 LABEL description="Bookmark manager for the wizards"
 LABEL org.opencontainers.image.source="https://github.com/goniszewski/grimoire"
 
-RUN mkdir -p /etc/s6-overlay/s6-rc.d/grimoire /etc/s6-overlay/s6-rc.d/user/contents.d && \
-    mkdir -p /app/data
+RUN mkdir -p /etc/s6-overlay/s6-rc.d/grimoire /etc/s6-overlay/s6-rc.d/user/contents.d /app/data
 
 # Different build strategy based on architecture
 ARG TARGETARCH
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-      # ARM64 build - avoid libc-bin issues
-      apt-get update && \
-      apt-mark hold libc-bin && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        xz-utils wget python3 python3-pip build-essential && \
-      rm -rf /var/lib/apt/lists/*; \
+    # ARM64 build - avoid libc-bin issues
+    apt-get update && \
+    apt-mark hold libc-bin && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    xz-utils wget python3 python3-pip build-essential && \
+    rm -rf /var/lib/apt/lists/*; \
     else \
-      # Standard installation for other architectures
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        xz-utils python3 python3-pip wget build-essential && \
-      rm -rf /var/lib/apt/lists/*; \
+    # Standard installation for other architectures
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    xz-utils python3 python3-pip wget build-essential && \
+    rm -rf /var/lib/apt/lists/*; \
     fi
 
 ARG S6_OVERLAY_VERSION=3.1.6.2
 RUN case "${TARGETARCH}" in \
-        "amd64") S6_ARCH="x86_64" ;; \
-        "arm64") S6_ARCH="aarch64" ;; \
-        "386") S6_ARCH="i686" ;; \
-        "arm/v7") S6_ARCH="armhf" ;; \
-        "arm/v6") S6_ARCH="arm" ;; \
-        *) S6_ARCH="x86_64" && echo "Warning: Unknown architecture ${TARGETARCH}, defaulting to x86_64" ;; \
+    "amd64") S6_ARCH="x86_64" ;; \
+    "arm64") S6_ARCH="aarch64" ;; \
+    "386") S6_ARCH="i686" ;; \
+    "arm/v7") S6_ARCH="armhf" ;; \
+    "arm/v6") S6_ARCH="arm" ;; \
+    *) S6_ARCH="x86_64" && echo "Warning: Unknown architecture ${TARGETARCH}, defaulting to x86_64" ;; \
     esac && \
     echo "Architecture: Docker ${TARGETARCH} -> s6-overlay ${S6_ARCH}" && \
     wget -q -O /tmp/s6-overlay-noarch.tar.xz https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz && \
@@ -72,14 +73,19 @@ ENV NODE_ENV=production \
     NODE_OPTIONS="--max-old-space-size=4096"
 RUN bun --bun run build
 
-FROM builder AS release
+FROM base AS release
 
-COPY --from=dependencies /app/node_modules ./node_modules
+RUN adduser --disabled-password --gecos '' grimoire
+RUN mkdir -p /app/data && chown -R grimoire:grimoire /app/data && chmod 766 /app/data
+WORKDIR /app
+
+# Copy only the necessary files for the release
 COPY --from=build /app/build ./build
 COPY --from=build /app/migrations ./migrations
 COPY --from=build /app/migrate.js ./migrate.js
 COPY --from=build /app/package.json ./package.json
 COPY docker-entrypoint.sh /
+
 ENV NODE_ENV=production \
     PUBLIC_ORIGIN=${PUBLIC_ORIGIN:-http://localhost:5173} \
     ORIGIN=${PUBLIC_ORIGIN:-http://localhost:5173} \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,5 @@
 FROM --platform=$BUILDPLATFORM oven/bun:1.2-alpine AS base
+RUN adduser --disabled-password --gecos '' --uid 10001 grimoire
 
 FROM base AS builder
 LABEL maintainer="Grimoire Developers <contact@grimoire.pro>"
@@ -49,7 +50,6 @@ ENV S6_KEEP_ENV=1 \
 
 RUN bun i -g svelte-kit@latest
 
-RUN adduser --disabled-password --gecos '' grimoire
 RUN mkdir -p /app/data && chown -R grimoire:grimoire /app/data && chmod 766 /app/data
 WORKDIR /app
 
@@ -73,7 +73,6 @@ RUN bun --bun run build
 
 FROM base AS release
 
-RUN adduser --disabled-password --gecos '' grimoire
 RUN mkdir -p /app/data && chown -R grimoire:grimoire /app/data && chmod 766 /app/data
 WORKDIR /app
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,100 @@
+FROM --platform=$BUILDPLATFORM oven/bun:1.2-alpine AS base
+
+FROM base AS builder
+LABEL maintainer="Grimoire Developers <contact@grimoire.pro>"
+LABEL description="Bookmark manager for the wizards"
+LABEL org.opencontainers.image.source="https://github.com/goniszewski/grimoire"
+
+RUN mkdir -p /etc/s6-overlay/s6-rc.d/grimoire /etc/s6-overlay/s6-rc.d/user/contents.d /app/data
+
+# Different build strategy based on architecture
+ARG TARGETARCH
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+    # ARM64 build - avoid libc-bin issues in Alpine
+    apk update && \
+    apk add --no-cache \
+    xz wget python3 py3-pip build-base; \
+    else \
+    # Standard installation for other architectures
+    apk update && \
+    apk add --no-cache \
+    xz wget python3 py3-pip build-base; \
+    fi
+
+
+ARG S6_OVERLAY_VERSION=3.1.6.2
+RUN case "${TARGETARCH}" in \
+    "amd64") S6_ARCH="x86_64" ;; \
+    "arm64") S6_ARCH="aarch64" ;; \
+    "386") S6_ARCH="i686" ;; \
+    "arm/v7") S6_ARCH="armhf" ;; \
+    "arm/v6") S6_ARCH="arm" ;; \
+    *) S6_ARCH="x86_64" && echo "Warning: Unknown architecture ${TARGETARCH}, defaulting to x86_64" ;; \
+    esac && \
+    echo "Architecture: Docker ${TARGETARCH} -> s6-overlay ${S6_ARCH}" && \
+    wget -q -O /tmp/s6-overlay-noarch.tar.xz https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz && \
+    wget -q -O /tmp/s6-overlay-${S6_ARCH}.tar.xz https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-${S6_ARCH}.tar.xz && \
+    rm /tmp/s6-overlay-*xz
+
+COPY docker/etc/s6-overlay /etc/s6-overlay/
+RUN chmod +x /etc/s6-overlay/s6-rc.d/grimoire/run
+
+ENV S6_KEEP_ENV=1 \
+    S6_SERVICES_GRACETIME=15000 \
+    S6_KILL_GRACETIME=10000 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SYNC_DISKS=1
+
+RUN bun i -g svelte-kit@latest
+
+RUN adduser --disabled-password --gecos '' grimoire
+RUN mkdir -p /app/data && chown -R grimoire:grimoire /app/data && chmod 766 /app/data
+WORKDIR /app
+
+FROM builder AS dependencies
+COPY package.json bun.lockb ./
+RUN bun install --frozen-lockfile && \
+    bun install --frozen-lockfile --production
+
+FROM builder AS build
+COPY --from=dependencies /app/node_modules ./node_modules
+COPY . .
+RUN bun run svelte-kit sync
+ARG PUBLIC_ORIGIN="http://localhost:5173"
+ARG PORT=5173
+ARG PUBLIC_HTTPS_ONLY="false"
+ARG PUBLIC_SIGNUP_DISABLED="false"
+ARG BODY_SIZE_LIMIT="5000000"
+ENV NODE_ENV=production \
+    NODE_OPTIONS="--max-old-space-size=4096"
+RUN bun --bun run build
+
+FROM base AS release
+
+RUN adduser --disabled-password --gecos '' grimoire
+RUN mkdir -p /app/data && chown -R grimoire:grimoire /app/data && chmod 766 /app/data
+WORKDIR /app
+
+# Copy only the necessary files for the release
+COPY --from=build /app/build ./build
+COPY --from=build /app/migrations ./migrations
+COPY --from=build /app/migrate.js ./migrate.js
+COPY --from=build /app/package.json ./package.json
+COPY docker-entrypoint.sh /
+
+ENV NODE_ENV=production \
+    PUBLIC_ORIGIN=${PUBLIC_ORIGIN:-http://localhost:5173} \
+    ORIGIN=${PUBLIC_ORIGIN:-http://localhost:5173} \
+    PORT=${PORT:-5173} \
+    PUBLIC_HTTPS_ONLY=${PUBLIC_HTTPS_ONLY:-false} \
+    PUBLIC_SIGNUP_DISABLED=${PUBLIC_SIGNUP_DISABLED:-false} \
+    BODY_SIZE_LIMIT=${BODY_SIZE_LIMIT:-5000000}
+
+RUN chmod +x /docker-entrypoint.sh
+USER grimoire
+EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:$PORT/api/health || exit 1
+ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
# Description:
This PR refines the Dockerfile by splitting the build and release stages into separate images to reduce dependency noise. The build stage is now isolated, ensuring the release image is cleaner and more lightweight. Additionally, the node_modules directory is no longer copied, as the server has already been built, making that step unnecessary.

To further optimize the image size, a new Dockerfile is introduced based on Alpine. This version is a smaller image that uses Alpine-specific commands instead of Debian commands, ensuring reduced size without sacrificing functionality.


# Result:
```bash
docker image ls | grep grimoire
thegameprofi/grimoire    alpine      88b2537f2420   15 minutes ago   95.4MB
thegameprofi/grimoire    latest      c9abcecaabb6   19 minutes ago   227MB
goniszewski/grimoire     latest      d7724382aafb   6 weeks ago      875MB
```

# Changes:

- Multi-stage Dockerfile: Split the process into separate images using FROM in different stages.
    - Build Stage: Contains dependencies and build steps.
    - Release Stage: Contains only the necessary release files, reducing the final image size.
- Removed node_modules copy: Since the server is already built, there's no need to include node_modules.
- Added Alpine-based Dockerfile: This image uses Alpine as the base, with equivalent Debian commands converted for compatibility.