### PR TITLE
Fix HTTPS issues in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM --platform=$BUILDPLATFORM oven/bun:1.2 AS base
 LABEL maintainer="Grimoire Developers <contact@grimoire.pro>"
 LABEL description="Bookmark manager for the wizards"
 LABEL org.opencontainers.image.source="https://github.com/goniszewski/grimoire"
-RUN adduser --disabled-password --gecos '' --uid 10001 grimoire
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    adduser --disabled-password --gecos '' --uid 10001 grimoire
 
 FROM base AS builder
 
@@ -15,13 +18,13 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
     apt-get update && \
     apt-mark hold libc-bin && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    xz-utils wget python3 python3-pip build-essential && \
+    ca-certificates xz-utils wget python3 python3-pip build-essential && \
     rm -rf /var/lib/apt/lists/*; \
     else \
     # Standard installation for other architectures
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    xz-utils python3 python3-pip wget build-essential && \
+    ca-certificates xz-utils python3 python3-pip wget build-essential && \
     rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,13 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
     apt-get update && \
     apt-mark hold libc-bin && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates xz-utils wget python3 python3-pip build-essential && \
+    xz-utils wget python3 python3-pip build-essential && \
     rm -rf /var/lib/apt/lists/*; \
     else \
     # Standard installation for other architectures
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates xz-utils python3 python3-pip wget build-essential && \
+    xz-utils python3 python3-pip wget build-essential && \
     rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,5 +1,6 @@
 FROM --platform=$BUILDPLATFORM oven/bun:1.2-alpine AS base
-RUN adduser --disabled-password --gecos '' --uid 10001 grimoire
+RUN apk add --no-cache ca-certificates && update-ca-certificates && \
+    adduser --disabled-password --gecos '' --uid 10001 grimoire
 
 FROM base AS builder
 LABEL maintainer="Grimoire Developers <contact@grimoire.pro>"
@@ -14,12 +15,14 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
     # ARM64 build - avoid libc-bin issues in Alpine
     apk update && \
     apk add --no-cache \
-    xz wget python3 py3-pip build-base; \
+    ca-certificates xz wget python3 py3-pip build-base && \
+    update-ca-certificates; \
     else \
     # Standard installation for other architectures
     apk update && \
     apk add --no-cache \
-    xz wget python3 py3-pip build-base; \
+    ca-certificates xz wget python3 py3-pip build-base && \
+    update-ca-certificates; \
     fi
 
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -15,14 +15,12 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
     # ARM64 build - avoid libc-bin issues in Alpine
     apk update && \
     apk add --no-cache \
-    ca-certificates xz wget python3 py3-pip build-base && \
-    update-ca-certificates; \
+    xz wget python3 py3-pip build-base; \
     else \
     # Standard installation for other architectures
     apk update && \
     apk add --no-cache \
-    ca-certificates xz wget python3 py3-pip build-base && \
-    update-ca-certificates; \
+    xz wget python3 py3-pip build-base; \
     fi
 
 


### PR DESCRIPTION
## Summary
- install ca-certificates in Docker images to allow HTTPS metadata fetch

## Testing
- `bun run lint` *(fails: code style issues found in 59 files)*
- `bun run test:unit` *(fails: ENETUNREACH during metadata tests)*

------
https://chatgpt.com/codex/tasks/task_b_68515ec4e520832abae0f090461b496f