### PR TITLE
release(1.0.1): publish patch release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ coverage/
 .omc/
 *.timestamp-*.mjs
 .env
+*.tsbuildinfo
 
 # Internal development artifacts not suitable for the public repo
 docs/superpowers/

--- a/API.md
+++ b/API.md
@@ -2393,7 +2393,7 @@ Request:
 curl -X POST http://127.0.0.1:3210/mcp \
   -H "Authorization: Bearer limp_it_example" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0.0"}}}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0.1"}}}'
 ```
 
 Response:
@@ -2410,7 +2410,7 @@ Content-Type: application/json
     "capabilities": {},
     "serverInfo": {
       "name": "grimoire",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 No unreleased changes.
 
+## [1.0.1] - 2026-08-03
+
+### Fixed
+- The one-command installer now defaults to the current release version instead
+  of the stale `0.1.0-beta`.
+- GitHub issue and repository extraction now accepts `www.github.com` URLs and
+  keeps stripping a trailing `.git` from repository names.
+- Outbound HTTP requests identify as `Grimoire/<version>` (derived from the
+  packaged version) instead of the stale `LittleImp/0.0`.
+- The sqlite-vec index is rebuilt in a single atomic transaction at daemon start.
+- E2E mocks, test fixtures, and release docs aligned with the 1.0.x version
+  identity and the `goniszewski/grimoire` repository.
+
 ## [0.1.0-beta] - 2026-05-28
 
 ### Added

--- a/Formula/grimoire.rb
+++ b/Formula/grimoire.rb
@@ -6,11 +6,11 @@ class Grimoire < Formula
   depends_on "oven-sh/bun/bun"
 
   if OS.mac?
-    url "https://github.com/goniszewski/grimoire/releases/download/v1.0.0/little-imp-1.0.0-macos.tar.gz"
-    sha256 "000000000000000000000000000000000000000000000000000000000000000a"
+    url "https://github.com/goniszewski/grimoire/releases/download/v1.0.1/little-imp-1.0.1-macos.tar.gz"
+    sha256 "a8c934821cc8db588ef9b3213f013c4cd99f1ae23ba8f18e400727191a9d49c1"
   elsif OS.linux?
-    url "https://github.com/goniszewski/grimoire/releases/download/v1.0.0/little-imp-1.0.0-linux.tar.gz"
-    sha256 "000000000000000000000000000000000000000000000000000000000000000b"
+    url "https://github.com/goniszewski/grimoire/releases/download/v1.0.1/little-imp-1.0.1-linux.tar.gz"
+    sha256 "42cf4ea63bb31ea2380a0b3c8c4c65f7af943974ce1024dd9562a2484e343cff"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <br>
 
 [![Quality Gates](https://github.com/goniszewski/grimoire/actions/workflows/quality.yml/badge.svg?branch=main)](https://github.com/goniszewski/grimoire/actions/workflows/quality.yml)
-![Release target](https://img.shields.io/badge/release-1.0.0-7c3aed)
+![Release target](https://img.shields.io/badge/release-1.0.1-7c3aed)
 ![Bun 1.x](https://img.shields.io/badge/Bun-1.x-black)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littleimpd",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/daemon/src/api/contract.ts
+++ b/daemon/src/api/contract.ts
@@ -3031,7 +3031,7 @@ export const apiContract = {
         {
           title: "Call the MCP endpoint",
           request:
-            'curl -X POST http://127.0.0.1:3210/mcp \\\n  -H "Authorization: Bearer limp_it_example" \\\n  -H "Content-Type: application/json" \\\n  -d \'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0.0"}}}\'',
+            'curl -X POST http://127.0.0.1:3210/mcp \\\n  -H "Authorization: Bearer limp_it_example" \\\n  -H "Content-Type: application/json" \\\n  -d \'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0.1"}}}\'',
           response: {
             status: 200,
             contentType: "application/json",
@@ -3043,7 +3043,7 @@ export const apiContract = {
                 capabilities: {},
                 serverInfo: {
                   name: "grimoire",
-                  version: "1.0.0",
+                  version: "1.0.1",
                 },
               },
             },

--- a/daemon/src/db/embedding-repository.ts
+++ b/daemon/src/db/embedding-repository.ts
@@ -123,12 +123,30 @@ export class EmbeddingRepository {
         .query<EmbeddingRow, []>("SELECT * FROM embeddings")
         .all();
 
-      for (const table of this.listVectorTables()) {
-        this.db.run(`DELETE FROM ${table}`);
-      }
-      for (const row of rows) {
-        this.upsertVectorIndex(row.bookmark_id, row.model, row.dimensions, row.vector);
-      }
+      // One transaction for the whole rebuild: per-row transactions would be
+      // thousands of BEGIN/COMMIT cycles on every daemon start, and the single
+      // transaction also keeps the index atomic if a crash interrupts a boot.
+      this.db.transaction(() => {
+        for (const table of this.listVectorTables()) {
+          this.db.run(`DELETE FROM ${table}`);
+        }
+        for (const row of rows) {
+          const table = vectorTableName(row.dimensions);
+          this.db.exec(
+            `CREATE VIRTUAL TABLE IF NOT EXISTS ${table} USING vec0(
+              bookmark_id TEXT PRIMARY KEY,
+              model TEXT PARTITION KEY,
+              embedding FLOAT[${row.dimensions}] distance_metric=cosine
+            )`
+          );
+          this.db
+            .query<unknown, [string, string, Uint8Array]>(
+              `INSERT INTO ${table} (bookmark_id, model, embedding)
+               VALUES (?, ?, ?)`
+            )
+            .run(row.bookmark_id, row.model, row.vector);
+        }
+      })();
     } catch (error) {
       this.disableVectorIndex(error);
     }

--- a/daemon/src/media/bookmark-media.ts
+++ b/daemon/src/media/bookmark-media.ts
@@ -4,6 +4,7 @@ import { existsSync, rmSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { join, resolve, sep } from "node:path";
 import { isPrivateHost } from "../lib/network.js";
+import { version as APP_VERSION } from "../../package.json";
 import type { BookmarkMediaKind, BookmarkMediaRow } from "../db/types.js";
 
 export interface BookmarkMediaCandidate {
@@ -281,7 +282,7 @@ async function fetchMedia(candidate: BookmarkMediaCandidate): Promise<{
       response = await fetch(source.toString(), {
         headers: {
           Accept: "image/avif,image/webp,image/png,image/jpeg,image/gif,image/x-icon,*/*;q=0.2",
-          "User-Agent": "Mozilla/5.0 (compatible; Grimoire/1.0.0; +https://github.com/goniszewski/grimoire)",
+          "User-Agent": `Mozilla/5.0 (compatible; Grimoire/${APP_VERSION}; +https://github.com/goniszewski/grimoire)`,
         },
         redirect: "manual",
         signal: controller.signal,

--- a/daemon/src/media/bookmark-media.ts
+++ b/daemon/src/media/bookmark-media.ts
@@ -281,7 +281,7 @@ async function fetchMedia(candidate: BookmarkMediaCandidate): Promise<{
       response = await fetch(source.toString(), {
         headers: {
           Accept: "image/avif,image/webp,image/png,image/jpeg,image/gif,image/x-icon,*/*;q=0.2",
-          "User-Agent": "Mozilla/5.0 (compatible; LittleImp/0.0; +https://github.com/goniszewski/little-imp)",
+          "User-Agent": "Mozilla/5.0 (compatible; Grimoire/1.0.0; +https://github.com/goniszewski/grimoire)",
         },
         redirect: "manual",
         signal: controller.signal,

--- a/daemon/src/pipeline/extractors/github-issues.ts
+++ b/daemon/src/pipeline/extractors/github-issues.ts
@@ -53,7 +53,7 @@ async function ghIssueFetch(path: string): Promise<unknown> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "LittleImp/0.0",
+    "User-Agent": "Grimoire/1.0.0",
   };
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
@@ -79,7 +79,8 @@ async function ghIssueFetch(path: string): Promise<unknown> {
 export function parseGitHubIssueUrl(url: string): GitHubIssueUrl | null {
   try {
     const parsedUrl = new URL(url);
-    if (parsedUrl.hostname !== "github.com") return null;
+    // GitHub redirects www.github.com to github.com; treat both as canonical.
+    if (parsedUrl.hostname.replace(/^www\./, "") !== "github.com") return null;
 
     const parts = parsedUrl.pathname.split("/").filter(Boolean);
     if (parts.length < 4 || parts[2] !== "issues") return null;
@@ -90,6 +91,7 @@ export function parseGitHubIssueUrl(url: string): GitHubIssueUrl | null {
 
     return {
       owner: parts[0],
+      // A trailing .git is common in pasted repo URLs; the API rejects it.
       repo: parts[1].replace(/\.git$/, ""),
       number,
     };

--- a/daemon/src/pipeline/extractors/github-issues.ts
+++ b/daemon/src/pipeline/extractors/github-issues.ts
@@ -7,6 +7,7 @@
  */
 
 import { ExtractionResult } from "./types.js";
+import { version as APP_VERSION } from "../../../package.json";
 
 const GITHUB_API = "https://api.github.com";
 const TIMEOUT_MS = 15_000;
@@ -53,7 +54,7 @@ async function ghIssueFetch(path: string): Promise<unknown> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "Grimoire/1.0.0",
+    "User-Agent": `Grimoire/${APP_VERSION}`,
   };
   if (token) headers["Authorization"] = `Bearer ${token}`;
 

--- a/daemon/src/pipeline/extractors/github.ts
+++ b/daemon/src/pipeline/extractors/github.ts
@@ -38,7 +38,7 @@ async function ghFetch(path: string): Promise<unknown> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "LittleImp/0.0",
+    "User-Agent": "Grimoire/1.0.0",
   };
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
@@ -58,9 +58,11 @@ async function ghFetch(path: string): Promise<unknown> {
 export function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
   try {
     const u = new URL(url);
-    if (u.hostname !== "github.com") return null;
+    // GitHub redirects www.github.com to github.com; treat both as canonical.
+    if (u.hostname.replace(/^www\./, "") !== "github.com") return null;
     const parts = u.pathname.split("/").filter(Boolean);
     if (parts.length < 2) return null;
+    // A trailing .git is common in pasted repo URLs; the API rejects it.
     return { owner: parts[0], repo: parts[1].replace(/\.git$/, "") };
   } catch {
     return null;

--- a/daemon/src/pipeline/extractors/github.ts
+++ b/daemon/src/pipeline/extractors/github.ts
@@ -10,6 +10,7 @@
  */
 
 import { ExtractionResult } from "./types.js";
+import { version as APP_VERSION } from "../../../package.json";
 
 const GITHUB_API = "https://api.github.com";
 const TIMEOUT_MS = 15_000;
@@ -38,7 +39,7 @@ async function ghFetch(path: string): Promise<unknown> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "Grimoire/1.0.0",
+    "User-Agent": `Grimoire/${APP_VERSION}`,
   };
   if (token) headers["Authorization"] = `Bearer ${token}`;
 

--- a/daemon/src/pipeline/extractors/stackoverflow.ts
+++ b/daemon/src/pipeline/extractors/stackoverflow.ts
@@ -10,6 +10,7 @@
  */
 
 import { ExtractionResult } from "./types.js";
+import { version as APP_VERSION } from "../../../package.json";
 
 const SE_API = "https://api.stackexchange.com/2.3";
 const TIMEOUT_MS = 15_000;
@@ -49,7 +50,7 @@ async function seFetch(path: string, site: string): Promise<unknown> {
     const res = await fetch(
       `${SE_API}${path}${path.includes("?") ? "&" : "?"}${siteParam}${keyParam}`,
       {
-        headers: { "User-Agent": "Grimoire/1.0.0" },
+        headers: { "User-Agent": `Grimoire/${APP_VERSION}` },
         signal: controller.signal,
       }
     );

--- a/daemon/src/pipeline/extractors/stackoverflow.ts
+++ b/daemon/src/pipeline/extractors/stackoverflow.ts
@@ -49,7 +49,7 @@ async function seFetch(path: string, site: string): Promise<unknown> {
     const res = await fetch(
       `${SE_API}${path}${path.includes("?") ? "&" : "?"}${siteParam}${keyParam}`,
       {
-        headers: { "User-Agent": "LittleImp/0.0" },
+        headers: { "User-Agent": "Grimoire/1.0.0" },
         signal: controller.signal,
       }
     );

--- a/daemon/src/pipeline/extractors/youtube.ts
+++ b/daemon/src/pipeline/extractors/youtube.ts
@@ -124,7 +124,7 @@ async function fetchCaptionTracks(videoId: string): Promise<TimedTextTrack[]> {
       headers: {
         "Content-Type": "application/json",
         "User-Agent":
-          "Mozilla/5.0 (compatible; LittleImp/0.0; +https://github.com/goniszewski/little-imp)",
+          "Mozilla/5.0 (compatible; Grimoire/1.0.0; +https://github.com/goniszewski/grimoire)",
       },
       body,
     });

--- a/daemon/src/pipeline/extractors/youtube.ts
+++ b/daemon/src/pipeline/extractors/youtube.ts
@@ -14,6 +14,7 @@
 import { ExtractionResult } from "./types.js";
 import { log } from "../../logger.js";
 import { isPrivateHost } from "../../lib/network.js";
+import { version as APP_VERSION } from "../../../package.json";
 
 const TIMEOUT_MS = 15_000;
 const MAX_TRANSCRIPT_CHARS = 500_000;
@@ -124,7 +125,7 @@ async function fetchCaptionTracks(videoId: string): Promise<TimedTextTrack[]> {
       headers: {
         "Content-Type": "application/json",
         "User-Agent":
-          "Mozilla/5.0 (compatible; Grimoire/1.0.0; +https://github.com/goniszewski/grimoire)",
+          `Mozilla/5.0 (compatible; Grimoire/${APP_VERSION}; +https://github.com/goniszewski/grimoire)`,
       },
       body,
     });

--- a/daemon/src/pipeline/fetcher.ts
+++ b/daemon/src/pipeline/fetcher.ts
@@ -10,7 +10,7 @@
 import { isPrivateHost } from "../lib/network.js";
 
 const USER_AGENT =
-  "Mozilla/5.0 (compatible; LittleImp/0.0; +https://github.com/goniszewski/little-imp)";
+  "Mozilla/5.0 (compatible; Grimoire/1.0.0; +https://github.com/goniszewski/grimoire)";
 
 const FETCH_TIMEOUT_MS = 20_000;
 /** Reject responses larger than this to prevent memory exhaustion. */

--- a/daemon/src/pipeline/fetcher.ts
+++ b/daemon/src/pipeline/fetcher.ts
@@ -8,9 +8,10 @@
  */
 
 import { isPrivateHost } from "../lib/network.js";
+import { version as APP_VERSION } from "../../package.json";
 
 const USER_AGENT =
-  "Mozilla/5.0 (compatible; Grimoire/1.0.0; +https://github.com/goniszewski/grimoire)";
+  `Mozilla/5.0 (compatible; Grimoire/${APP_VERSION}; +https://github.com/goniszewski/grimoire)`;
 
 const FETCH_TIMEOUT_MS = 20_000;
 /** Reject responses larger than this to prevent memory exhaustion. */

--- a/daemon/src/test/cli-update.test.ts
+++ b/daemon/src/test/cli-update.test.ts
@@ -172,12 +172,12 @@ describe("littleimp update CLI", () => {
         html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0-beta.1",
       },
       {
-        tag_name: "v1.0.1",
-        name: "Grimoire 1.0.1",
+        tag_name: "v1.1.0",
+        name: "Grimoire 1.1.0",
         draft: false,
         prerelease: false,
         published_at: "2026-05-17T12:00:00Z",
-        html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.0.1",
+        html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0",
       },
     ]);
 
@@ -194,20 +194,20 @@ describe("littleimp update CLI", () => {
     expect(harness.calls[0].url).toBe("https://updates.example.test/releases");
     expect(harness.calls[0].init?.headers).toEqual({
       accept: "application/vnd.github+json",
-      "user-agent": "littleimp-update-check/1.0.0",
+      "user-agent": "littleimp-update-check/1.0.1",
     });
     expect(JSON.parse(harness.stdout[0])).toEqual({
-      current_version: "1.0.0",
+      current_version: "1.0.1",
       update_available: true,
       source: "https://updates.example.test/releases",
       channel: "stable",
       latest: {
-        version: "1.0.1",
-        tag: "v1.0.1",
-        name: "Grimoire 1.0.1",
+        version: "1.1.0",
+        tag: "v1.1.0",
+        name: "Grimoire 1.1.0",
         prerelease: false,
         published_at: "2026-05-17T12:00:00Z",
-        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.0.1",
+        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0",
       },
     });
   });
@@ -294,7 +294,7 @@ describe("littleimp update CLI", () => {
 
     expect(code).toBe(0);
     expect(harness.stdout.join("\n")).toContain("Grimoire is up to date");
-    expect(harness.stdout.join("\n")).toContain("1.0.0");
+    expect(harness.stdout.join("\n")).toContain("1.0.1");
   });
 
   it("uses LITTLEIMP_UPDATE_SOURCE when no source flag is provided", async () => {
@@ -343,7 +343,7 @@ describe("littleimp update CLI", () => {
     expect(harness.spawnCalls[0].args).toContain("--upgrade");
     expect(harness.fetchCalls[0].url).toBe("http://127.0.0.1:3210/health");
     expect(JSON.parse(harness.stdout[0])).toMatchObject({
-      current_version: "1.0.0",
+      current_version: "1.0.1",
       upgraded_version: fixture.version,
       archive: fixture.archivePath,
       checksum_verified: true,
@@ -470,7 +470,7 @@ describe("littleimp update CLI", () => {
   });
 
   it("checks the release source before downloading the latest compatible upgrade when no version is provided", async () => {
-    const fixture = createUpgradeArchiveFixture({ version: "1.0.1" });
+    const fixture = createUpgradeArchiveFixture({ version: "1.1.0" });
     const stdout: string[] = [];
     const stderr: string[] = [];
     const fetchCalls: FetchCall[] = [];

--- a/daemon/src/test/embedding-repository.test.ts
+++ b/daemon/src/test/embedding-repository.test.ts
@@ -43,6 +43,45 @@ describe("EmbeddingRepository vector index", () => {
     ].sort(byBookmarkId));
   });
 
+  it("rebuildVectorIndex restores vector tables from the embeddings table when available", () => {
+    const db = makeTestDb();
+    const bookmarks = new BookmarkRepository(db);
+    const embeddings = new EmbeddingRepository(db);
+
+    const vectorIndexAvailable = embeddings.isVectorIndexAvailable(2);
+    if (!vectorIndexAvailable) {
+      expect(vectorIndexAvailable).toBe(false);
+      return;
+    }
+
+    const first = bookmarks.create("https://vectors.example.com/rebuild-a", "Rebuild A");
+    const second = bookmarks.create("https://vectors.example.com/rebuild-b", "Rebuild B");
+    embeddings.upsert(first.id, "test-model", [1, 0]);
+    embeddings.upsert(second.id, "test-model", [0, 1]);
+
+    // Simulate a stale or partially-written index (e.g. a crash between the
+    // embeddings write and the vec mirror, or a pre-sqlite-vec database).
+    db.run("DELETE FROM embedding_vec_2");
+    expect(
+      db.query<{ c: number }, []>("SELECT COUNT(*) AS c FROM embedding_vec_2").get()?.c
+    ).toBe(0);
+
+    embeddings.rebuildVectorIndex();
+
+    const restoredRows = db
+      .query<{ bookmark_id: string }, []>(
+        "SELECT bookmark_id FROM embedding_vec_2 ORDER BY bookmark_id"
+      )
+      .all();
+    expect(restoredRows.map((row) => row.bookmark_id)).toEqual([first.id, second.id]);
+
+    const nearest = embeddings.findNearest("test-model", [0.99, 0.01], {
+      limit: 1,
+      excludeBookmarkId: null,
+    });
+    expect(nearest.map((row) => row.bookmarkId)).toEqual([first.id]);
+  });
+
   it("returns nearest neighbors from sqlite-vec with cosine similarity scores when available", () => {
     const db = makeTestDb();
     const bookmarks = new BookmarkRepository(db);

--- a/daemon/src/test/embedding-repository.test.ts
+++ b/daemon/src/test/embedding-repository.test.ts
@@ -73,7 +73,9 @@ describe("EmbeddingRepository vector index", () => {
         "SELECT bookmark_id FROM embedding_vec_2 ORDER BY bookmark_id"
       )
       .all();
-    expect(restoredRows.map((row) => row.bookmark_id)).toEqual([first.id, second.id]);
+    expect(restoredRows.map((row) => row.bookmark_id).sort()).toEqual(
+      [first.id, second.id].sort()
+    );
 
     const nearest = embeddings.findNearest("test-model", [0.99, 0.01], {
       limit: 1,

--- a/daemon/src/test/integration/updates.test.ts
+++ b/daemon/src/test/integration/updates.test.ts
@@ -48,12 +48,12 @@ describe("Updates API", () => {
           html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0-beta.1",
         },
         {
-          tag_name: "v1.0.1",
-          name: "Grimoire 1.0.1",
+          tag_name: "v1.1.0",
+          name: "Grimoire 1.1.0",
           draft: false,
           prerelease: false,
           published_at: "2026-05-18T10:00:00Z",
-          html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.0.1",
+          html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0",
         },
       ]);
     }) as typeof fetch;
@@ -65,7 +65,7 @@ describe("Updates API", () => {
     expect(calls[0].url).toBe(source);
     expect(calls[0].init?.headers).toEqual({
       accept: "application/vnd.github+json",
-      "user-agent": "littleimp-update-check/1.0.0",
+      "user-agent": "littleimp-update-check/1.0.1",
     });
     const json = await res.json() as {
       data: {
@@ -84,17 +84,17 @@ describe("Updates API", () => {
       };
     };
     expect(json.data).toEqual({
-      current_version: "1.0.0",
+      current_version: "1.0.1",
       update_available: true,
       source,
       channel: "stable",
       latest: {
-        version: "1.0.1",
-        tag: "v1.0.1",
-        name: "Grimoire 1.0.1",
+        version: "1.1.0",
+        tag: "v1.1.0",
+        name: "Grimoire 1.1.0",
         prerelease: false,
         published_at: "2026-05-18T10:00:00Z",
-        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.0.1",
+        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0",
       },
     });
   });

--- a/daemon/src/test/pipeline/github-issues.test.ts
+++ b/daemon/src/test/pipeline/github-issues.test.ts
@@ -134,6 +134,38 @@ describe("GitHub issue extraction", () => {
     expect(result.markdown).toContain("The import preview already has the folder data.");
   });
 
+  it("routes www.github.com issue URLs to the issue extractor", async () => {
+    const calls: string[] = [];
+    const wwwIssueUrl = "https://www.github.com/littleimp/demo/issues/42";
+
+    globalThis.fetch = mockFetch(async (input) => {
+      const url = String(input);
+      calls.push(url);
+
+      if (url.endsWith("/repos/littleimp/demo/issues/42")) {
+        return jsonResponse({
+          number: 42,
+          title: "Preserve imported bookmark folders",
+          body: "Importer should keep the nested browser folder context.",
+          state: "open",
+          labels: [{ name: "bug" }],
+          created_at: "2026-06-01T10:00:00Z",
+          updated_at: "2026-06-02T10:00:00Z",
+          user: { login: "alice" },
+          assignees: [{ login: "bob" }],
+          comments: 0,
+        });
+      }
+
+      return jsonResponse({ message: "not found" }, 404);
+    });
+
+    const result = await extractContent(wwwIssueUrl, makeFetchedHtml(wwwIssueUrl), null);
+
+    expect(calls.some((url) => url.endsWith("/repos/littleimp/demo/issues/42"))).toBe(true);
+    expect(result.title).toBe("Preserve imported bookmark folders");
+  });
+
   it("leaves non-issue GitHub URLs on the repository extractor", async () => {
     const calls: string[] = [];
     const pullUrl = "https://github.com/littleimp/demo/pull/42";
@@ -171,9 +203,21 @@ describe("GitHub issue extraction", () => {
       repo: "demo",
       number: 42,
     });
+    expect(parseGitHubIssueUrl("https://www.github.com/littleimp/demo/issues/42")).toEqual({
+      owner: "littleimp",
+      repo: "demo",
+      number: 42,
+    });
+    expect(parseGitHubIssueUrl("https://github.com/littleimp/demo.git/issues/42")).toEqual({
+      owner: "littleimp",
+      repo: "demo",
+      number: 42,
+    });
     expect(parseGitHubIssueUrl("https://github.com/littleimp/demo/pull/42")).toBeNull();
+    expect(parseGitHubIssueUrl("https://www.github.com/littleimp/demo/pull/42")).toBeNull();
     expect(parseGitHubIssueUrl("https://github.com/littleimp/demo")).toBeNull();
     expect(parseGitHubIssueUrl("https://example.com/littleimp/demo/issues/42")).toBeNull();
+    expect(parseGitHubIssueUrl("https://www.example.com/littleimp/demo/issues/42")).toBeNull();
   });
 
   it("sends GITHUB_TOKEN as an authorization header when configured", async () => {

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -8840,7 +8840,7 @@
       "examples": [
         {
           "title": "Call the MCP endpoint",
-          "request": "curl -X POST http://127.0.0.1:3210/mcp \\\n  -H \"Authorization: Bearer limp_it_example\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"curl\",\"version\":\"1.0.0\"}}}'",
+          "request": "curl -X POST http://127.0.0.1:3210/mcp \\\n  -H \"Authorization: Bearer limp_it_example\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"curl\",\"version\":\"1.0.1\"}}}'",
           "response": {
             "status": 200,
             "contentType": "application/json",
@@ -8852,7 +8852,7 @@
                 "capabilities": {},
                 "serverInfo": {
                   "name": "grimoire",
-                  "version": "1.0.0"
+                  "version": "1.0.1"
                 }
               }
             }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## Can I sync my bookmarks across devices?
 
-Not yet. Grimoire is local-first and single-user for `1.0.0`. Backups
+Not yet. Grimoire is local-first and single-user for `1.0.1`. Backups
 are snapshot-based, so you can move or restore a saved backup, but there is no
 continuous multi-device sync service.
 
@@ -37,14 +37,14 @@ source is configured. Settings can also check for update availability. See
 
 ## Does it work on Windows?
 
-There is no native Windows installer in `1.0.0`. Docker on Windows with
+There is no native Windows installer in `1.0.1`. Docker on Windows with
 WSL2 is the supported path. Keep Docker port publishing bound to loopback, for
 example `127.0.0.1:3210:3210`.
 
 ## Can I run it on a server?
 
 Yes through Docker, but Grimoire itself is not a public-server product in
-`1.0.0`. Keep the daemon loopback-bound or put an authenticated tunnel,
+`1.0.1`. Keep the daemon loopback-bound or put an authenticated tunnel,
 VPN, or reverse proxy in front of it before traffic reaches Grimoire. See
 [security-boundaries.md](./security-boundaries.md) and
 [docker-deployment.md](./docker-deployment.md).

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -3,7 +3,7 @@
 Product Requirements Document (PRD)
 
 Version: v0.6
-Status: Living document aligned to the `1.0.0` release
+Status: Living document aligned to the `1.0.1` release
 Author: Robert Goniszewski
 Date: May 2026
 
@@ -27,7 +27,7 @@ Users save URLs and the system:
 
 Current product state:
 
-- `1.0.0` is the current release
+- `1.0.1` is the current release
 - core save, extract, keyword search, semantic search, hybrid search, and review flows exist
 - local/S3-compatible backup and restore flows exist with checksum validation, rollback directory creation, and restart-required restore responses
 - Docker deployment, release archives, the one-command installer, the Homebrew alternate path, and Streamable HTTP MCP integration are supported local-first entry points

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,9 +1,9 @@
 # Grimoire Release Checklist
 
-Release target: `0.1.0-beta`
+Release target: `1.0.0`
 
 Use this checklist before tagging, while publishing, and immediately after
-publishing a beta build. Items that require published GitHub release artifacts
+publishing a release build. Items that require published GitHub release artifacts
 are called out explicitly.
 
 ## Preflight
@@ -23,10 +23,10 @@ The MVP native installer supports this exact OS matrix:
 
 | Target | Architecture | Service manager | Release artifact | Required before publish |
 |---|---|---|---|---|
-| macOS 12+ arm64 | Apple Silicon | LaunchAgent | `little-imp-0.1.0-beta-macos.tar.gz` | Validate on the available Apple Silicon host or VM. |
-| macOS 12+ x64 | Intel | LaunchAgent | `little-imp-0.1.0-beta-macos.tar.gz` | Best-effort target; validated when Intel hardware or an x64 macOS VM is available. macOS arm64 is the validated Mac target. |
-| Ubuntu 24.04 LTS | Host architecture | systemd user unit | `little-imp-0.1.0-beta-linux.tar.gz` | Run the Linux matrix smoke or record why Docker/systemd was unavailable. |
-| Debian 12 | Host architecture | systemd user unit | `little-imp-0.1.0-beta-linux.tar.gz` | Run the Linux matrix smoke or record why Docker/systemd was unavailable. |
+| macOS 12+ arm64 | Apple Silicon | LaunchAgent | `little-imp-1.0.0-macos.tar.gz` | Validate on the available Apple Silicon host or VM. |
+| macOS 12+ x64 | Intel | LaunchAgent | `little-imp-1.0.0-macos.tar.gz` | Best-effort target; validated when Intel hardware or an x64 macOS VM is available. macOS arm64 is the validated Mac target. |
+| Ubuntu 24.04 LTS | Host architecture | systemd user unit | `little-imp-1.0.0-linux.tar.gz` | Run the Linux matrix smoke or record why Docker/systemd was unavailable. |
+| Debian 12 | Host architecture | systemd user unit | `little-imp-1.0.0-linux.tar.gz` | Run the Linux matrix smoke or record why Docker/systemd was unavailable. |
 
 Record command output, host details, and deviations in
 [installer-matrix-validation.md](./installer-matrix-validation.md).
@@ -35,10 +35,10 @@ Record command output, host details, and deviations in
 
 - From a clean checkout, run `npm run package:release`.
 - Confirm `release/` contains:
-  - `little-imp-0.1.0-beta-macos.tar.gz`
-  - `little-imp-0.1.0-beta-macos.tar.gz.sha256`
-  - `little-imp-0.1.0-beta-linux.tar.gz`
-  - `little-imp-0.1.0-beta-linux.tar.gz.sha256`
+  - `little-imp-1.0.0-macos.tar.gz`
+  - `little-imp-1.0.0-macos.tar.gz.sha256`
+  - `little-imp-1.0.0-linux.tar.gz`
+  - `little-imp-1.0.0-linux.tar.gz.sha256`
   - `release-manifest.json`
 - Run `npm run release:validate`.
 - Verify checksums from inside `release/` with `shasum -a 256 -c *.sha256`
@@ -50,7 +50,7 @@ Record command output, host details, and deviations in
 - Confirm root `install.sh` is executable and references the current release
   target.
 - Before artifacts are published, validate local archive install and upgrade by
-  extracting `release/little-imp-0.1.0-beta-PLATFORM.tar.gz`, running
+  extracting `release/little-imp-1.0.0-PLATFORM.tar.gz`, running
   `daemon/install.sh`, and then running `daemon/install.sh --upgrade` over the
   existing install.
 - Run the packaged CLI local archive upgrade path against a downloaded archive
@@ -62,7 +62,7 @@ Record command output, host details, and deviations in
   containers are available.
 - On macOS, run `cd daemon && ./install.sh` on a clean profile or VM for each
   available architecture, then verify
-  `curl http://127.0.0.1:3210/health` returns `version: "0.1.0-beta"`.
+  `curl http://127.0.0.1:3210/health` returns `version: "1.0.0"`.
 - Verify LaunchAgent or systemd user service starts the daemon after login.
 - Run `cd daemon && ./install.sh --upgrade` over an existing native install and
   confirm data is preserved.
@@ -72,11 +72,11 @@ Record command output, host details, and deviations in
 After the GitHub release artifacts are published:
 
 - Run the one-command installer path against the published release URL:
-  `curl -fsSL https://raw.githubusercontent.com/goniszewski/little-imp/v0.1.0-beta/install.sh | bash`.
+  `curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.0/install.sh | bash`.
 - Run the one-command upgrade path over an existing install:
-  `curl -fsSL https://raw.githubusercontent.com/goniszewski/little-imp/v0.1.0-beta/install.sh | bash -s -- --upgrade`.
+  `curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.0/install.sh | bash -s -- --upgrade`.
 - Run the packaged CLI upgrade path against the published release artifacts:
-  `littleimp update install --version 0.1.0-beta`.
+  `littleimp update install --version 1.0.0`.
 - If any post-publish installer check fails, keep the release in draft or mark
   it pre-release until the failing path is corrected or documented.
 
@@ -93,9 +93,9 @@ After the GitHub release artifacts are published:
   expected 404 caused by unpublished archive URLs.
 - After release artifacts are published, run
   `brew install goniszewski/grimoire/grimoire`.
-- Confirm `littleimp --help` reports `0.1.0-beta`.
+- Confirm `littleimp --help` reports `1.0.0`.
 - Start the Homebrew service with `brew services start grimoire`, then verify
-  `curl http://127.0.0.1:3210/health` reports `version: "0.1.0-beta"`.
+  `curl http://127.0.0.1:3210/health` reports `version: "1.0.0"`.
 - Stop the Homebrew service with `brew services stop grimoire`.
 - Run `brew uninstall grimoire` and confirm
   `$(brew --prefix)/var/little-imp` remains unless it is explicitly removed.
@@ -110,7 +110,7 @@ After the GitHub release artifacts are published:
   check, daemon health, upgrade data preservation, and uninstall without purge.
 - After the GitHub release assets are publicly downloadable, run
   `npm run test:e2e:installed:published`; the command downloads
-  `v0.1.0-beta` from the GitHub release URL, verifies the archive checksum and
+  `v1.0.0` from the GitHub release URL, verifies the archive checksum and
   detached signature, then runs the same installed-app smoke in an isolated
   temporary home.
 - If the smoke fails, inspect the temp root printed by the command, especially
@@ -213,7 +213,7 @@ Apply these thresholds consistently:
 - Confirm `README.md`, `CHANGELOG.md`, `SECURITY.md`, `tasks/README.md`,
   `docs/roadmap.md`, `docs/prd.md`, `docs/overview.md`,
   `docs/release-checklist.md`, and `docs/update-system.md` all name
-  `0.1.0-beta` as the current release target and `v0.1.0-beta` as the release
+  `1.0.0` as the current release target and `v1.0.0` as the release
   tag where tag-qualified URLs are required.
 - Confirm links in `README.md`, `CONTRIBUTING.md`, and `tasks/README.md` resolve to existing files.
 - Confirm backup, Docker, MCP, and API source-of-truth docs match the shipped routes and defaults.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,6 @@
 # Grimoire Release Checklist
 
-Release target: `1.0.0`
+Release target: `1.0.1`
 
 Use this checklist before tagging, while publishing, and immediately after
 publishing a release build. Items that require published GitHub release artifacts
@@ -23,10 +23,10 @@ The MVP native installer supports this exact OS matrix:
 
 | Target | Architecture | Service manager | Release artifact | Required before publish |
 |---|---|---|---|---|
-| macOS 12+ arm64 | Apple Silicon | LaunchAgent | `little-imp-1.0.0-macos.tar.gz` | Validate on the available Apple Silicon host or VM. |
-| macOS 12+ x64 | Intel | LaunchAgent | `little-imp-1.0.0-macos.tar.gz` | Best-effort target; validated when Intel hardware or an x64 macOS VM is available. macOS arm64 is the validated Mac target. |
-| Ubuntu 24.04 LTS | Host architecture | systemd user unit | `little-imp-1.0.0-linux.tar.gz` | Run the Linux matrix smoke or record why Docker/systemd was unavailable. |
-| Debian 12 | Host architecture | systemd user unit | `little-imp-1.0.0-linux.tar.gz` | Run the Linux matrix smoke or record why Docker/systemd was unavailable. |
+| macOS 12+ arm64 | Apple Silicon | LaunchAgent | `little-imp-1.0.1-macos.tar.gz` | Validate on the available Apple Silicon host or VM. |
+| macOS 12+ x64 | Intel | LaunchAgent | `little-imp-1.0.1-macos.tar.gz` | Best-effort target; validated when Intel hardware or an x64 macOS VM is available. macOS arm64 is the validated Mac target. |
+| Ubuntu 24.04 LTS | Host architecture | systemd user unit | `little-imp-1.0.1-linux.tar.gz` | Run the Linux matrix smoke or record why Docker/systemd was unavailable. |
+| Debian 12 | Host architecture | systemd user unit | `little-imp-1.0.1-linux.tar.gz` | Run the Linux matrix smoke or record why Docker/systemd was unavailable. |
 
 Record command output, host details, and deviations in
 [installer-matrix-validation.md](./installer-matrix-validation.md).
@@ -35,10 +35,10 @@ Record command output, host details, and deviations in
 
 - From a clean checkout, run `npm run package:release`.
 - Confirm `release/` contains:
-  - `little-imp-1.0.0-macos.tar.gz`
-  - `little-imp-1.0.0-macos.tar.gz.sha256`
-  - `little-imp-1.0.0-linux.tar.gz`
-  - `little-imp-1.0.0-linux.tar.gz.sha256`
+  - `little-imp-1.0.1-macos.tar.gz`
+  - `little-imp-1.0.1-macos.tar.gz.sha256`
+  - `little-imp-1.0.1-linux.tar.gz`
+  - `little-imp-1.0.1-linux.tar.gz.sha256`
   - `release-manifest.json`
 - Run `npm run release:validate`.
 - Verify checksums from inside `release/` with `shasum -a 256 -c *.sha256`
@@ -50,7 +50,7 @@ Record command output, host details, and deviations in
 - Confirm root `install.sh` is executable and references the current release
   target.
 - Before artifacts are published, validate local archive install and upgrade by
-  extracting `release/little-imp-1.0.0-PLATFORM.tar.gz`, running
+  extracting `release/little-imp-1.0.1-PLATFORM.tar.gz`, running
   `daemon/install.sh`, and then running `daemon/install.sh --upgrade` over the
   existing install.
 - Run the packaged CLI local archive upgrade path against a downloaded archive
@@ -62,7 +62,7 @@ Record command output, host details, and deviations in
   containers are available.
 - On macOS, run `cd daemon && ./install.sh` on a clean profile or VM for each
   available architecture, then verify
-  `curl http://127.0.0.1:3210/health` returns `version: "1.0.0"`.
+  `curl http://127.0.0.1:3210/health` returns `version: "1.0.1"`.
 - Verify LaunchAgent or systemd user service starts the daemon after login.
 - Run `cd daemon && ./install.sh --upgrade` over an existing native install and
   confirm data is preserved.
@@ -72,11 +72,11 @@ Record command output, host details, and deviations in
 After the GitHub release artifacts are published:
 
 - Run the one-command installer path against the published release URL:
-  `curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.0/install.sh | bash`.
+  `curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.1/install.sh | bash`.
 - Run the one-command upgrade path over an existing install:
-  `curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.0/install.sh | bash -s -- --upgrade`.
+  `curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.1/install.sh | bash -s -- --upgrade`.
 - Run the packaged CLI upgrade path against the published release artifacts:
-  `littleimp update install --version 1.0.0`.
+  `littleimp update install --version 1.0.1`.
 - If any post-publish installer check fails, keep the release in draft or mark
   it pre-release until the failing path is corrected or documented.
 
@@ -93,9 +93,9 @@ After the GitHub release artifacts are published:
   expected 404 caused by unpublished archive URLs.
 - After release artifacts are published, run
   `brew install goniszewski/grimoire/grimoire`.
-- Confirm `littleimp --help` reports `1.0.0`.
+- Confirm `littleimp --help` reports `1.0.1`.
 - Start the Homebrew service with `brew services start grimoire`, then verify
-  `curl http://127.0.0.1:3210/health` reports `version: "1.0.0"`.
+  `curl http://127.0.0.1:3210/health` reports `version: "1.0.1"`.
 - Stop the Homebrew service with `brew services stop grimoire`.
 - Run `brew uninstall grimoire` and confirm
   `$(brew --prefix)/var/little-imp` remains unless it is explicitly removed.
@@ -110,7 +110,7 @@ After the GitHub release artifacts are published:
   check, daemon health, upgrade data preservation, and uninstall without purge.
 - After the GitHub release assets are publicly downloadable, run
   `npm run test:e2e:installed:published`; the command downloads
-  `v1.0.0` from the GitHub release URL, verifies the archive checksum and
+  `v1.0.1` from the GitHub release URL, verifies the archive checksum and
   detached signature, then runs the same installed-app smoke in an isolated
   temporary home.
 - If the smoke fails, inspect the temp root printed by the command, especially
@@ -213,7 +213,7 @@ Apply these thresholds consistently:
 - Confirm `README.md`, `CHANGELOG.md`, `SECURITY.md`, `tasks/README.md`,
   `docs/roadmap.md`, `docs/prd.md`, `docs/overview.md`,
   `docs/release-checklist.md`, and `docs/update-system.md` all name
-  `1.0.0` as the current release target and `v1.0.0` as the release
+  `1.0.1` as the current release target and `v1.0.1` as the release
   tag where tag-qualified URLs are required.
 - Confirm links in `README.md`, `CONTRIBUTING.md`, and `tasks/README.md` resolve to existing files.
 - Confirm backup, Docker, MCP, and API source-of-truth docs match the shipped routes and defaults.

--- a/docs/update-system.md
+++ b/docs/update-system.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the update behavior shipped for the `0.1.0-beta`
+This document describes the update behavior shipped for the `1.0.0`
 release target and separates it from post-MVP update-management ideas.
 
 Grimoire updates are explicit and user-controlled. The shipped system can
@@ -11,7 +11,7 @@ the archive, run the native installer in upgrade mode, restart the daemon, and
 verify the daemon reports the upgraded version. It does not perform automatic
 updates.
 
-## Shipped In 0.1.0-beta
+## Shipped In 1.0.0
 
 Implemented update paths:
 
@@ -80,7 +80,7 @@ verifies the published checksum, verifies a detached signature when published,
 and delegates to the native installer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v0.1.0-beta/install.sh | bash -s -- --upgrade
+curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.0/install.sh | bash -s -- --upgrade
 ```
 
 If no detached signature is published, the installer prints a checksum-only
@@ -88,7 +88,7 @@ warning and does not claim signature verification.
 
 ## Rollback
 
-Rollback is manual in `0.1.0-beta`.
+Rollback is manual in `1.0.0`.
 
 Failed upgrades after installer execution print rollback guidance that directs
 the user to rerun the previous verified release installer with `--upgrade`.
@@ -106,14 +106,14 @@ Current shipped configuration:
 |---|---|---|
 | `LITTLEIMP_UPDATE_SOURCE` | CLI and daemon update check | Override the default GitHub Releases-compatible source. |
 | `LITTLEIMP_RELEASE_BASE_URL` | CLI upgrade and one-command installer | Override the base URL that contains archive, checksum, and optional signature files. |
-| `LITTLEIMP_VERSION` | One-command installer | Select the release version to download. Defaults to `0.1.0-beta`. |
+| `LITTLEIMP_VERSION` | One-command installer | Select the release version to download. Defaults to `1.0.0`. |
 
 Beta builds check the beta channel by default. Stable builds check the stable
 channel by default.
 
 ## Deferred Update Management
 
-These ideas are not shipped in `0.1.0-beta`:
+These ideas are not shipped in `1.0.0`:
 
 - Automatic scheduled update checks.
 - System tray notifications or critical-update banners.

--- a/docs/update-system.md
+++ b/docs/update-system.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the update behavior shipped for the `1.0.0`
+This document describes the update behavior shipped for the `1.0.1`
 release target and separates it from post-MVP update-management ideas.
 
 Grimoire updates are explicit and user-controlled. The shipped system can
@@ -11,7 +11,7 @@ the archive, run the native installer in upgrade mode, restart the daemon, and
 verify the daemon reports the upgraded version. It does not perform automatic
 updates.
 
-## Shipped In 1.0.0
+## Shipped In 1.0.1
 
 Implemented update paths:
 
@@ -80,7 +80,7 @@ verifies the published checksum, verifies a detached signature when published,
 and delegates to the native installer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.0/install.sh | bash -s -- --upgrade
+curl -fsSL https://raw.githubusercontent.com/goniszewski/grimoire/v1.0.1/install.sh | bash -s -- --upgrade
 ```
 
 If no detached signature is published, the installer prints a checksum-only
@@ -88,7 +88,7 @@ warning and does not claim signature verification.
 
 ## Rollback
 
-Rollback is manual in `1.0.0`.
+Rollback is manual in `1.0.1`.
 
 Failed upgrades after installer execution print rollback guidance that directs
 the user to rerun the previous verified release installer with `--upgrade`.
@@ -106,14 +106,14 @@ Current shipped configuration:
 |---|---|---|
 | `LITTLEIMP_UPDATE_SOURCE` | CLI and daemon update check | Override the default GitHub Releases-compatible source. |
 | `LITTLEIMP_RELEASE_BASE_URL` | CLI upgrade and one-command installer | Override the base URL that contains archive, checksum, and optional signature files. |
-| `LITTLEIMP_VERSION` | One-command installer | Select the release version to download. Defaults to `1.0.0`. |
+| `LITTLEIMP_VERSION` | One-command installer | Select the release version to download. Defaults to `1.0.1`. |
 
 Beta builds check the beta channel by default. Stable builds check the stable
 channel by default.
 
 ## Deferred Update Management
 
-These ideas are not shipped in `1.0.0`:
+These ideas are not shipped in `1.0.1`:
 
 - Automatic scheduled update checks.
 - System tray notifications or critical-update banners.

--- a/e2e/business-requirements.spec.ts
+++ b/e2e/business-requirements.spec.ts
@@ -184,7 +184,7 @@ test.describe("Documented business requirements smoke", () => {
     await expect(page.getByRole("heading", { name: "Backup & Restore" })).toBeVisible();
 
     await page.getByRole("button", { name: /check for updates/i }).click();
-    await expect(page.getByText(/Grimoire 0\.1\.0-beta is up to date/i)).toBeVisible();
+    await expect(page.getByText(/Grimoire 1\.0\.0 is up to date/i)).toBeVisible();
     await expect.poll(() => daemon.requests.updateChecks).toBe(1);
 
     await page.getByTitle("Verify backup integrity").click();

--- a/e2e/business-requirements.spec.ts
+++ b/e2e/business-requirements.spec.ts
@@ -184,7 +184,7 @@ test.describe("Documented business requirements smoke", () => {
     await expect(page.getByRole("heading", { name: "Backup & Restore" })).toBeVisible();
 
     await page.getByRole("button", { name: /check for updates/i }).click();
-    await expect(page.getByText(/Grimoire 1\.0\.0 is up to date/i)).toBeVisible();
+    await expect(page.getByText(/Grimoire 1\.0\.1 is up to date/i)).toBeVisible();
     await expect.poll(() => daemon.requests.updateChecks).toBe(1);
 
     await page.getByTitle("Verify backup integrity").click();

--- a/e2e/mock-daemon.ts
+++ b/e2e/mock-daemon.ts
@@ -228,9 +228,9 @@ function makeRestoreResult(bookmarkCount: number): RestoreResultDto {
 
 function makeUpdateResult(): UpdateCheckResultDto {
   return {
-    current_version: "0.1.0-beta",
+    current_version: "1.0.0",
     update_available: false,
-    source: "https://github.com/goniszewski/little-imp/releases",
+    source: "https://github.com/goniszewski/grimoire/releases",
     channel: "beta",
     latest: null,
   };

--- a/e2e/mock-daemon.ts
+++ b/e2e/mock-daemon.ts
@@ -228,7 +228,7 @@ function makeRestoreResult(bookmarkCount: number): RestoreResultDto {
 
 function makeUpdateResult(): UpdateCheckResultDto {
   return {
-    current_version: "1.0.0",
+    current_version: "1.0.1",
     update_available: false,
     source: "https://github.com/goniszewski/grimoire/releases",
     channel: "beta",

--- a/e2e/update-notification.spec.ts
+++ b/e2e/update-notification.spec.ts
@@ -57,17 +57,17 @@ async function setupBaseMocks(page: Page) {
 function makeUpdateAvailableResponse(): { data: UpdateCheckResultDto } {
   return {
     data: {
-      current_version: "0.1.0-beta",
+      current_version: "1.0.0",
       update_available: true,
-      source: "https://github.com/goniszewski/little-imp/releases",
+      source: "https://github.com/goniszewski/grimoire/releases",
       channel: "stable",
       latest: {
-        version: "0.2.0",
-        tag: "v0.2.0",
-        name: "v0.2.0",
+        version: "1.1.0",
+        tag: "v1.1.0",
+        name: "v1.1.0",
         prerelease: false,
         published_at: "2026-07-15T00:00:00Z",
-        url: "https://github.com/goniszewski/little-imp/releases/tag/v0.2.0",
+        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0",
       },
     },
   };
@@ -76,9 +76,9 @@ function makeUpdateAvailableResponse(): { data: UpdateCheckResultDto } {
 function makeUpToDateResponse(): { data: UpdateCheckResultDto } {
   return {
     data: {
-      current_version: "0.1.0-beta",
+      current_version: "1.0.0",
       update_available: false,
-      source: "https://github.com/goniszewski/little-imp/releases",
+      source: "https://github.com/goniszewski/grimoire/releases",
       channel: "stable",
       latest: null,
     },
@@ -103,7 +103,7 @@ test.describe("In-app update notification", () => {
     await page.goto("/");
 
     // Assert: the update banner is visible
-    const banner = page.getByRole("note").filter({ hasText: /Grimoire v0\.2\.0 is available/ });
+    const banner = page.getByRole("note").filter({ hasText: /Grimoire v1\.1\.0 is available/ });
     await expect(banner).toBeVisible();
     // The dismiss button should be present
     await expect(banner.getByRole("button", { name: /Dismiss/i })).toBeVisible();
@@ -138,7 +138,7 @@ test.describe("In-app update notification", () => {
     await page.goto("/");
 
     // Banner should be visible
-    const banner = page.getByRole("note").filter({ hasText: /Grimoire v0\.2\.0 is available/ });
+    const banner = page.getByRole("note").filter({ hasText: /Grimoire v1\.1\.0 is available/ });
     await expect(banner).toBeVisible();
 
     // Dismiss it
@@ -160,7 +160,7 @@ test.describe("In-app update notification", () => {
 
     await page.goto("/");
 
-    const banner = page.getByRole("note").filter({ hasText: /Grimoire v0\.2\.0 is available/ });
+    const banner = page.getByRole("note").filter({ hasText: /Grimoire v1\.1\.0 is available/ });
     await expect(banner).toBeVisible();
 
     // Click "View update"

--- a/e2e/update-notification.spec.ts
+++ b/e2e/update-notification.spec.ts
@@ -57,7 +57,7 @@ async function setupBaseMocks(page: Page) {
 function makeUpdateAvailableResponse(): { data: UpdateCheckResultDto } {
   return {
     data: {
-      current_version: "1.0.0",
+      current_version: "1.0.1",
       update_available: true,
       source: "https://github.com/goniszewski/grimoire/releases",
       channel: "stable",
@@ -76,7 +76,7 @@ function makeUpdateAvailableResponse(): { data: UpdateCheckResultDto } {
 function makeUpToDateResponse(): { data: UpdateCheckResultDto } {
   return {
     data: {
-      current_version: "1.0.0",
+      current_version: "1.0.1",
       update_available: false,
       source: "https://github.com/goniszewski/grimoire/releases",
       channel: "stable",

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 APP_NAME="Grimoire"
 REPO="goniszewski/grimoire"
-VERSION="${LITTLEIMP_VERSION:-0.1.0-beta}"
+VERSION="${LITTLEIMP_VERSION:-1.0.0}"
 RELEASE_BASE_URL="${LITTLEIMP_RELEASE_BASE_URL:-https://github.com/${REPO}/releases/download/v${VERSION}}"
 
 MODE_ARGS=()

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 APP_NAME="Grimoire"
 REPO="goniszewski/grimoire"
-VERSION="${LITTLEIMP_VERSION:-1.0.0}"
+VERSION="${LITTLEIMP_VERSION:-1.0.1}"
 RELEASE_BASE_URL="${LITTLEIMP_RELEASE_BASE_URL:-https://github.com/${REPO}/releases/download/v${VERSION}}"
 
 MODE_ARGS=()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "author": "Robert Goniszewski",
   "repository": { "type": "git", "url": "git+https://github.com/goniszewski/grimoire.git" },

--- a/scripts/homebrew-formula.test.ts
+++ b/scripts/homebrew-formula.test.ts
@@ -33,6 +33,10 @@ const releaseChecksumBaselines: Record<string, ReleaseChecksumBaseline> = {
     macos: "000000000000000000000000000000000000000000000000000000000000000a",
     linux: "000000000000000000000000000000000000000000000000000000000000000b",
   },
+  "1.0.1": {
+    macos: "a8c934821cc8db588ef9b3213f013c4cd99f1ae23ba8f18e400727191a9d49c1",
+    linux: "42cf4ea63bb31ea2380a0b3c8c4c65f7af943974ce1024dd9562a2484e343cff",
+  },
 };
 
 function packageVersion(): string {

--- a/src/components/UpdateAvailableBanner.test.tsx
+++ b/src/components/UpdateAvailableBanner.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { UpdateAvailableBanner } from "./UpdateAvailableBanner";
 
-function renderBanner(latestTag = "v0.2.0", currentVersion = "1.0.0", onDismiss = vi.fn()) {
+function renderBanner(latestTag = "v0.2.0", currentVersion = "1.0.1", onDismiss = vi.fn()) {
   return render(
     <MemoryRouter>
       <UpdateAvailableBanner
@@ -17,9 +17,9 @@ function renderBanner(latestTag = "v0.2.0", currentVersion = "1.0.0", onDismiss 
 
 describe("UpdateAvailableBanner", () => {
   it("renders the available version and current version", () => {
-    renderBanner("v0.2.0", "1.0.0");
+    renderBanner("v0.2.0", "1.0.1");
     expect(screen.getByText(/Grimoire v0.2.0 is available/)).toBeInTheDocument();
-    expect(screen.getByText(/current: 1.0.0/)).toBeInTheDocument();
+    expect(screen.getByText(/current: 1.0.1/)).toBeInTheDocument();
   });
 
   it("renders a 'View update' link that navigates to /settings", () => {
@@ -33,7 +33,7 @@ describe("UpdateAvailableBanner", () => {
 
   it("calls onDismiss when the dismiss button is clicked", () => {
     const onDismiss = vi.fn();
-    renderBanner("v0.2.0", "1.0.0", onDismiss);
+    renderBanner("v0.2.0", "1.0.1", onDismiss);
     fireEvent.click(screen.getByRole("button", { name: /Dismiss/i }));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });

--- a/src/components/UpdateAvailableBanner.test.tsx
+++ b/src/components/UpdateAvailableBanner.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { UpdateAvailableBanner } from "./UpdateAvailableBanner";
 
-function renderBanner(latestTag = "v0.2.0", currentVersion = "0.1.0-beta", onDismiss = vi.fn()) {
+function renderBanner(latestTag = "v0.2.0", currentVersion = "1.0.0", onDismiss = vi.fn()) {
   return render(
     <MemoryRouter>
       <UpdateAvailableBanner
@@ -17,9 +17,9 @@ function renderBanner(latestTag = "v0.2.0", currentVersion = "0.1.0-beta", onDis
 
 describe("UpdateAvailableBanner", () => {
   it("renders the available version and current version", () => {
-    renderBanner("v0.2.0", "0.1.0-beta");
+    renderBanner("v0.2.0", "1.0.0");
     expect(screen.getByText(/Grimoire v0.2.0 is available/)).toBeInTheDocument();
-    expect(screen.getByText(/current: 0.1.0-beta/)).toBeInTheDocument();
+    expect(screen.getByText(/current: 1.0.0/)).toBeInTheDocument();
   });
 
   it("renders a 'View update' link that navigates to /settings", () => {
@@ -33,7 +33,7 @@ describe("UpdateAvailableBanner", () => {
 
   it("calls onDismiss when the dismiss button is clicked", () => {
     const onDismiss = vi.fn();
-    renderBanner("v0.2.0", "0.1.0-beta", onDismiss);
+    renderBanner("v0.2.0", "1.0.0", onDismiss);
     fireEvent.click(screen.getByRole("button", { name: /Dismiss/i }));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });

--- a/src/components/UpdateAvailableBanner.tsx
+++ b/src/components/UpdateAvailableBanner.tsx
@@ -4,7 +4,7 @@ import { ArrowUpCircle, X } from "lucide-react";
 interface UpdateAvailableBannerProps {
   /** The tag name of the available update (e.g. "v0.2.0"). */
   latestTag: string;
-  /** The version string of the current app (e.g. "0.1.0-beta"). */
+  /** The version string of the current app (e.g. "1.0.0"). */
   currentVersion: string;
   /** Called when the user dismisses the banner. */
   onDismiss: () => void;

--- a/src/components/UpdateAvailableBanner.tsx
+++ b/src/components/UpdateAvailableBanner.tsx
@@ -4,7 +4,7 @@ import { ArrowUpCircle, X } from "lucide-react";
 interface UpdateAvailableBannerProps {
   /** The tag name of the available update (e.g. "v0.2.0"). */
   latestTag: string;
-  /** The version string of the current app (e.g. "1.0.0"). */
+  /** The version string of the current app (e.g. "1.0.1"). */
   currentVersion: string;
   /** Called when the user dismisses the banner. */
   onDismiss: () => void;

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -65,7 +65,7 @@ describe("daemon health API", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     mockHealthResponse({
       status: "ok",
-      version: "0.1.0-beta",
+      version: "1.0.0",
       uptime: 10_000,
       queueSize: 0,
     });
@@ -79,7 +79,7 @@ describe("daemon health API", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     mockHealthResponse({
       status: "ok",
-      version: "0.1.0-beta",
+      version: "1.0.0",
       uptime: 120_000,
       queueSize: 0,
     });

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -65,7 +65,7 @@ describe("daemon health API", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     mockHealthResponse({
       status: "ok",
-      version: "1.0.0",
+      version: "1.0.1",
       uptime: 10_000,
       queueSize: 0,
     });
@@ -79,7 +79,7 @@ describe("daemon health API", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     mockHealthResponse({
       status: "ok",
-      version: "1.0.0",
+      version: "1.0.1",
       uptime: 120_000,
       queueSize: 0,
     });

--- a/src/pages/Index.test.tsx
+++ b/src/pages/Index.test.tsx
@@ -426,7 +426,7 @@ describe("Index update notification banner", () => {
       showBanner: true,
       dismiss: vi.fn(),
       result: {
-        current_version: "1.0.0",
+        current_version: "1.0.1",
         update_available: true,
         source: "https://api.github.com/repos/goniszewski/grimoire/releases",
         channel: "stable",
@@ -439,7 +439,7 @@ describe("Index update notification banner", () => {
 
     expect(screen.getByTestId("update-banner")).toBeInTheDocument();
     expect(screen.getByTestId("update-tag")).toHaveTextContent("v1.1.0");
-    expect(screen.getByTestId("update-version")).toHaveTextContent("1.0.0");
+    expect(screen.getByTestId("update-version")).toHaveTextContent("1.0.1");
   });
 
   it("dismisses the update banner when dismiss is clicked", () => {
@@ -448,7 +448,7 @@ describe("Index update notification banner", () => {
       showBanner: true,
       dismiss,
       result: {
-        current_version: "1.0.0",
+        current_version: "1.0.1",
         update_available: true,
         source: "",
         channel: "stable",

--- a/src/pages/Index.test.tsx
+++ b/src/pages/Index.test.tsx
@@ -426,11 +426,11 @@ describe("Index update notification banner", () => {
       showBanner: true,
       dismiss: vi.fn(),
       result: {
-        current_version: "0.1.0-beta",
+        current_version: "1.0.0",
         update_available: true,
-        source: "https://api.github.com/repos/goniszewski/little-imp/releases",
+        source: "https://api.github.com/repos/goniszewski/grimoire/releases",
         channel: "stable",
-        latest: { version: "0.2.0", tag: "v0.2.0", name: "v0.2.0", prerelease: false, published_at: "2026-07-15", url: "https://github.com/goniszewski/little-imp/releases/tag/v0.2.0" },
+        latest: { version: "1.1.0", tag: "v1.1.0", name: "v1.1.0", prerelease: false, published_at: "2026-07-15", url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0" },
       },
       loading: false,
     });
@@ -438,8 +438,8 @@ describe("Index update notification banner", () => {
     renderIndex();
 
     expect(screen.getByTestId("update-banner")).toBeInTheDocument();
-    expect(screen.getByTestId("update-tag")).toHaveTextContent("v0.2.0");
-    expect(screen.getByTestId("update-version")).toHaveTextContent("0.1.0-beta");
+    expect(screen.getByTestId("update-tag")).toHaveTextContent("v1.1.0");
+    expect(screen.getByTestId("update-version")).toHaveTextContent("1.0.0");
   });
 
   it("dismisses the update banner when dismiss is clicked", () => {
@@ -448,11 +448,11 @@ describe("Index update notification banner", () => {
       showBanner: true,
       dismiss,
       result: {
-        current_version: "0.1.0-beta",
+        current_version: "1.0.0",
         update_available: true,
         source: "",
         channel: "stable",
-        latest: { version: "0.2.0", tag: "v0.2.0", name: "v0.2.0", prerelease: false, published_at: "2026-07-15", url: "" },
+        latest: { version: "1.1.0", tag: "v1.1.0", name: "v1.1.0", prerelease: false, published_at: "2026-07-15", url: "" },
       },
       loading: false,
     });

--- a/src/pages/Settings.test.tsx
+++ b/src/pages/Settings.test.tsx
@@ -169,7 +169,7 @@ beforeEach(() => {
   mockedGetDiagnostics.mockResolvedValue({
     data: {
       generated_at: "2026-05-27T08:00:00.000Z",
-      version: "0.1.0-beta",
+      version: "1.0.0",
       platform: { os: "darwin", arch: "arm64", node_env: "production", host: "127.0.0.1", port: 3210 },
       install: { mode: "native" },
       paths: {
@@ -198,10 +198,10 @@ beforeEach(() => {
   });
   mockedCheckForUpdates.mockResolvedValue({
     data: {
-      current_version: "0.1.0-beta",
+      current_version: "1.0.0",
       update_available: false,
-      source: "https://api.github.com/repos/goniszewski/little-imp/releases",
-      channel: "beta",
+      source: "https://api.github.com/repos/goniszewski/grimoire/releases",
+      channel: "stable",
       latest: null,
     },
   });
@@ -279,17 +279,17 @@ describe("Settings update checks", () => {
   it("checks for updates and shows the available release", async () => {
     mockedCheckForUpdates.mockResolvedValue({
       data: {
-        current_version: "0.1.0-beta",
+        current_version: "1.0.0",
         update_available: true,
-        source: "https://api.github.com/repos/goniszewski/little-imp/releases",
-        channel: "beta",
+        source: "https://api.github.com/repos/goniszewski/grimoire/releases",
+        channel: "stable",
         latest: {
-          version: "0.2.0-beta.1",
-          tag: "v0.2.0-beta.1",
-          name: "Little Imp 0.2.0 beta 1",
-          prerelease: true,
+          version: "1.1.0",
+          tag: "v1.1.0",
+          name: "Grimoire 1.1.0",
+          prerelease: false,
           published_at: "2026-05-19T10:00:00.000Z",
-          url: "https://github.com/goniszewski/little-imp/releases/tag/v0.2.0-beta.1",
+          url: "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0",
         },
       },
     });
@@ -301,10 +301,10 @@ describe("Settings update checks", () => {
     await waitFor(() => {
       expect(mockedCheckForUpdates).toHaveBeenCalledWith();
     });
-    expect(await screen.findByText(/v0\.2\.0-beta\.1 is available/)).toBeInTheDocument();
+    expect(await screen.findByText(/v1\.1\.0 is available/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View release" })).toHaveAttribute(
       "href",
-      "https://github.com/goniszewski/little-imp/releases/tag/v0.2.0-beta.1"
+      "https://github.com/goniszewski/grimoire/releases/tag/v1.1.0"
     );
   });
 });
@@ -593,14 +593,14 @@ describe("Settings diagnostics", () => {
     render(<Settings />, { wrapper: makeWrapper() });
 
     expect(await screen.findByText("Diagnostics")).toBeInTheDocument();
-    expect(screen.getByText("0.1.0-beta")).toBeInTheDocument();
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
     expect(screen.getByText("native · darwin/arm64")).toBeInTheDocument();
     expect(screen.getByText("/Users/me/.local/share/littleimp")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Copy diagnostics" }));
 
     await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('"version": "0.1.0-beta"'));
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('"version": "1.0.0"'));
     });
     expect(writeText.mock.calls[0][0]).not.toContain("openai-secret");
     expect(writeText.mock.calls[0][0]).not.toContain("s3-secret-key");

--- a/src/pages/Settings.test.tsx
+++ b/src/pages/Settings.test.tsx
@@ -169,7 +169,7 @@ beforeEach(() => {
   mockedGetDiagnostics.mockResolvedValue({
     data: {
       generated_at: "2026-05-27T08:00:00.000Z",
-      version: "1.0.0",
+      version: "1.0.1",
       platform: { os: "darwin", arch: "arm64", node_env: "production", host: "127.0.0.1", port: 3210 },
       install: { mode: "native" },
       paths: {
@@ -198,7 +198,7 @@ beforeEach(() => {
   });
   mockedCheckForUpdates.mockResolvedValue({
     data: {
-      current_version: "1.0.0",
+      current_version: "1.0.1",
       update_available: false,
       source: "https://api.github.com/repos/goniszewski/grimoire/releases",
       channel: "stable",
@@ -279,7 +279,7 @@ describe("Settings update checks", () => {
   it("checks for updates and shows the available release", async () => {
     mockedCheckForUpdates.mockResolvedValue({
       data: {
-        current_version: "1.0.0",
+        current_version: "1.0.1",
         update_available: true,
         source: "https://api.github.com/repos/goniszewski/grimoire/releases",
         channel: "stable",
@@ -593,14 +593,14 @@ describe("Settings diagnostics", () => {
     render(<Settings />, { wrapper: makeWrapper() });
 
     expect(await screen.findByText("Diagnostics")).toBeInTheDocument();
-    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getByText("1.0.1")).toBeInTheDocument();
     expect(screen.getByText("native · darwin/arm64")).toBeInTheDocument();
     expect(screen.getByText("/Users/me/.local/share/littleimp")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Copy diagnostics" }));
 
     await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('"version": "1.0.0"'));
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('"version": "1.0.1"'));
     });
     expect(writeText.mock.calls[0][0]).not.toContain("openai-secret");
     expect(writeText.mock.calls[0][0]).not.toContain("s3-secret-key");


### PR DESCRIPTION
## Summary

Patch release **1.0.1** — fixes release-blocking inconsistencies found during review, plus the version bump and release metadata.

> **Semver:** patch — no API/DB schema changes, no new features, bug fixes only.

## Changes

### Fixes
- `install.sh` now defaults to the current release version instead of the stale `0.1.0-beta` — a fresh one-command install would have fetched the old beta.
- GitHub issue/repository extraction:
  - accepts `www.github.com` URLs (previously fell through to the generic readability extractor and lost issue metadata),
  - keeps stripping a trailing `.git` from repo names (the API rejects it),
  - sends `Grimoire/<version>` as the User-Agent, derived from the packaged version instead of a hardcoded stale `LittleImp/0.0` (all six fetchers).
- The sqlite-vec index is rebuilt in a single atomic transaction at daemon start instead of thousands of per-row transactions.
- E2E mocks/specs, test fixtures, `release-checklist.md`, and `update-system.md` aligned with the 1.0.x version identity and `goniszewski/grimoire` repo (the 1.0.0 release doc required this but it was never done).

### Release
- Version bumped to `1.0.1` (root + daemon manifests, API/MCP contract, install.sh, docs, e2e).
- Release archives built; Homebrew formula + checksum baselines filled with the real 1.0.1 SHAs.
- CHANGELOG entry and regenerated API docs.

## Verification
- `npm run check` green: lint (0 errors), type-check, 311 frontend tests, 487 daemon tests, `docs:api:check`, production build.
- Release artifacts validated by `npm run release:validate` (checksum-only; detached `.asc` signatures to be added by the maintainer, GPG is unavailable in the agent environment).