### PR TITLE
fix(#212): retry invalid AI enrichment responses

### DIFF
--- a/daemon/src/ai/enrichment.ts
+++ b/daemon/src/ai/enrichment.ts
@@ -64,12 +64,34 @@ function parseResponse(raw: string): EnrichmentResponse | null {
   if (typeof parsed !== "object" || parsed === null) return null;
   const p = parsed as Record<string, unknown>;
 
-  const summary = typeof p.summary === "string" ? p.summary.trim() : "";
-  const confidence = typeof p.confidence === "number"
-    ? Math.max(0, Math.min(1, p.confidence))
-    : 0.5;
+  // Do not turn a provider-side empty or partial object into successful
+  // enrichment by filling in defaults. Every field in the prompt is required;
+  // otherwise a 200 response such as `{}` would be persisted as an empty
+  // summary, no tags, and the default "Other" category.
+  if (
+    !Object.prototype.hasOwnProperty.call(p, "summary") ||
+    !Object.prototype.hasOwnProperty.call(p, "tags") ||
+    !Object.prototype.hasOwnProperty.call(p, "category") ||
+    !Object.prototype.hasOwnProperty.call(p, "confidence")
+  ) {
+    return null;
+  }
 
-  const rawTags = Array.isArray(p.tags) ? p.tags : [];
+  if (
+    typeof p.summary !== "string" ||
+    !Array.isArray(p.tags) ||
+    typeof p.category !== "string" ||
+    typeof p.confidence !== "number" ||
+    !Number.isFinite(p.confidence)
+  ) {
+    return null;
+  }
+
+  const summary = p.summary.trim();
+  if (!summary) return null;
+  const confidence = Math.max(0, Math.min(1, p.confidence));
+
+  const rawTags = p.tags;
   const tags = rawTags
     .filter((t): t is string => typeof t === "string")
     .map((t) => t.toLowerCase().trim().replace(/[^a-z0-9-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, ""))
@@ -80,6 +102,12 @@ function parseResponse(raw: string): EnrichmentResponse | null {
   const category = VALID_CATEGORIES.has(rawCategory) ? rawCategory : "Other";
 
   return { summary, tags, category, confidence };
+}
+
+function validateResponse(raw: string): string | null {
+  return parseResponse(raw)
+    ? null
+    : "LLM returned incomplete or invalid enrichment response";
 }
 
 // ─── DB helpers ───────────────────────────────────────────────────────────────
@@ -143,7 +171,11 @@ export async function enrichBookmark(
       { role: "system", content: SYSTEM_PROMPT },
       { role: "user", content: buildUserMessage(title, content) },
     ],
-    { jsonMode: true, maxTokens: 512 }
+    {
+      jsonMode: true,
+      maxTokens: 512,
+      validateContent: validateResponse,
+    }
   );
 
   const result = parseResponse(rawResponse);

--- a/daemon/src/ai/llm-client.ts
+++ b/daemon/src/ai/llm-client.ts
@@ -35,6 +35,17 @@ export interface ChatMessage {
   content: string;
 }
 
+export interface LlmCompletionOptions {
+  jsonMode?: boolean;
+  maxTokens?: number;
+  /**
+   * Return an error message when a successful provider response is not usable
+   * for the caller. The client retries these responses like other transient
+   * provider failures.
+   */
+  validateContent?: (content: string) => string | null;
+}
+
 // ─── Error types ─────────────────────────────────────────────────────────────
 
 export class LlmError extends Error {
@@ -68,7 +79,7 @@ const REQUEST_TIMEOUT_MS = 30_000;
 export async function chatCompletion(
   config: LlmConfig,
   messages: ChatMessage[],
-  opts: { jsonMode?: boolean; maxTokens?: number } = {}
+  opts: LlmCompletionOptions = {}
 ): Promise<string> {
   const url = `${config.baseUrl.replace(/\/+$/, "")}/chat/completions`;
   const headers: Record<string, string> = {
@@ -126,17 +137,28 @@ export async function chatCompletion(
       try {
         json = await res.json();
       } catch {
-        throw new LlmError("Failed to parse LLM response JSON", false);
+        throw new LlmError("Failed to parse LLM response JSON", true);
       }
 
       const content = (json as { choices?: Array<{ message?: { content?: string } }> })
         ?.choices?.[0]?.message?.content;
 
       if (typeof content !== "string" || !content.trim()) {
-        throw new LlmError("LLM returned empty content", false);
+        throw new LlmError("LLM returned empty content", true);
       }
 
-      return content.trim();
+      const trimmedContent = content.trim();
+      const validationError = opts.validateContent?.(trimmedContent);
+      if (validationError) {
+        log.warn("LLM response failed validation (retryable)", {
+          attempt,
+          error: validationError,
+          model: config.model,
+        });
+        throw new LlmError(validationError, true);
+      }
+
+      return trimmedContent;
     } catch (err) {
       clearTimeout(timer);
 

--- a/daemon/src/ai/llm-provider.ts
+++ b/daemon/src/ai/llm-provider.ts
@@ -1,4 +1,10 @@
-import { ChatMessage, LlmConfig, LlmError, chatCompletion } from "./llm-client.js";
+import {
+  ChatMessage,
+  LlmCompletionOptions,
+  LlmConfig,
+  LlmError,
+  chatCompletion,
+} from "./llm-client.js";
 import { log } from "../logger.js";
 
 export type OpenAiCompatibleLlmProvider =
@@ -40,7 +46,7 @@ function anthropicMessagesUrl(baseUrl: string): string {
 function anthropicRequestBody(
   config: AnthropicLlmConfig,
   messages: ChatMessage[],
-  opts: { maxTokens?: number }
+  opts: LlmCompletionOptions
 ): Record<string, unknown> {
   const system = messages
     .filter((message) => message.role === "system")
@@ -77,7 +83,7 @@ function anthropicText(json: unknown): string {
 async function anthropicMessages(
   config: AnthropicLlmConfig,
   messages: ChatMessage[],
-  opts: { maxTokens?: number } = {}
+  opts: LlmCompletionOptions = {}
 ): Promise<string> {
   const url = anthropicMessagesUrl(config.baseUrl);
   const body = anthropicRequestBody(config, messages, opts);
@@ -122,12 +128,22 @@ async function anthropicMessages(
       try {
         json = await res.json();
       } catch {
-        throw new LlmError("Failed to parse Anthropic response JSON", false);
+        throw new LlmError("Failed to parse Anthropic response JSON", true);
       }
 
       const content = anthropicText(json);
       if (!content) {
-        throw new LlmError("Anthropic returned empty content", false);
+        throw new LlmError("Anthropic returned empty content", true);
+      }
+
+      const validationError = opts.validateContent?.(content);
+      if (validationError) {
+        log.warn("Anthropic response failed validation (retryable)", {
+          attempt,
+          error: validationError,
+          model: config.model,
+        });
+        throw new LlmError(validationError, true);
       }
 
       return content;
@@ -154,10 +170,10 @@ async function anthropicMessages(
 export async function providerChatCompletion(
   config: ProviderLlmConfig | LlmConfig,
   messages: ChatMessage[],
-  opts: { jsonMode?: boolean; maxTokens?: number } = {}
+  opts: LlmCompletionOptions = {}
 ): Promise<string> {
   if ("kind" in config && config.kind === "anthropic") {
-    return anthropicMessages(config, messages, { maxTokens: opts.maxTokens });
+    return anthropicMessages(config, messages, opts);
   }
   return chatCompletion(config, messages, opts);
 }

--- a/daemon/src/test/pipeline/ai-enrich.test.ts
+++ b/daemon/src/test/pipeline/ai-enrich.test.ts
@@ -159,15 +159,22 @@ describe("enrichBookmark", () => {
   it("throws when LLM returns invalid JSON", async () => {
     const bookmarkId = insertBookmark(db);
 
-    globalThis.fetch = mockFetch(async () => makeLlmResponse("not json at all }{"));
+    const invalidResponse = "not json at all }{";
+    globalThis.fetch = mockFetch(async () => makeLlmResponse(invalidResponse));
 
-    await expect(
-      enrichBookmark(db, LLM_CONFIG, {
-        bookmarkId,
-        title: "Title",
-        content: "Content",
-      })
-    ).rejects.toThrow();
+    const error = await enrichBookmark(db, LLM_CONFIG, {
+      bookmarkId,
+      title: "Title",
+      content: "Content",
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toBe("LLM returned incomplete or invalid enrichment response");
+    expect(message).not.toContain(invalidResponse);
   });
 
   it("throws when LLM returns markdown-fenced invalid JSON", async () => {
@@ -213,6 +220,72 @@ describe("enrichBookmark", () => {
       "SELECT summary FROM bookmark_content WHERE bookmark_id = ?"
     ).get(bookmarkId);
     expect(content?.summary).toBe("Fenced summary.");
+  });
+
+  it("retries a provider's empty JSON object before persisting enrichment", async () => {
+    const bookmarkId = insertBookmark(db);
+    let calls = 0;
+
+    globalThis.fetch = mockFetch(async () => {
+      calls++;
+      return calls === 1
+        ? makeLlmResponse("{}")
+        : makeLlmResponse(
+            JSON.stringify({
+              summary: "A recovered summary.",
+              tags: ["recovered"],
+              category: "Article",
+              confidence: 0.8,
+            })
+          );
+    });
+
+    await enrichBookmark(db, LLM_CONFIG, {
+      bookmarkId,
+      title: "Title",
+      content: "Content",
+    });
+
+    expect(calls).toBe(2);
+    const content = db
+      .query<{ summary: string | null }, [string]>(
+        "SELECT summary FROM bookmark_content WHERE bookmark_id = ?"
+      )
+      .get(bookmarkId);
+    expect(content?.summary).toBe("A recovered summary.");
+  });
+
+  it("retries a provider's malformed JSON before persisting enrichment", async () => {
+    const bookmarkId = insertBookmark(db);
+    let calls = 0;
+
+    globalThis.fetch = mockFetch(async () => {
+      calls++;
+      return calls === 1
+        ? makeLlmResponse('{")} { ":") { "}')
+        : makeLlmResponse(
+            JSON.stringify({
+              summary: "Another recovered summary.",
+              tags: ["recovered"],
+              category: "Tutorial",
+              confidence: 0.8,
+            })
+          );
+    });
+
+    await enrichBookmark(db, LLM_CONFIG, {
+      bookmarkId,
+      title: "Title",
+      content: "Content",
+    });
+
+    expect(calls).toBe(2);
+    const content = db
+      .query<{ summary: string | null }, [string]>(
+        "SELECT summary FROM bookmark_content WHERE bookmark_id = ?"
+      )
+      .get(bookmarkId);
+    expect(content?.summary).toBe("Another recovered summary.");
   });
 
   it("can refresh summary while preserving existing category and tags", async () => {


### PR DESCRIPTION
## Summary

- Treat incomplete, malformed, empty, and invalid AI enrichment responses as retryable.
- Validate the complete enrichment shape before persistence for OpenAI-compatible and Anthropic providers.
- Keep provider output out of retry logs and error messages.

Fixes #212

## Validation

- `npm run type-check`
- `bun test daemon/src/test/pipeline/ai-enrich.test.ts`
- `npm run test:daemon` (519 passed)
- `git diff --check`