### PR TITLE
fix(release): align published artifact checksums and URL

### DIFF
--- a/Formula/grimoire.rb
+++ b/Formula/grimoire.rb
@@ -7,10 +7,10 @@ class Grimoire < Formula
 
   if OS.mac?
     url "https://github.com/goniszewski/grimoire/releases/download/v1.1.0/little-imp-1.1.0-macos.tar.gz"
-    sha256 "f9435a3d956bf47aaa7b724319e49e41699b51d462d8474d91eaf5ca1f325cd2"
+    sha256 "c68bc963602a79631c76df223b9cc4a3709a0d382c0b117288f27c72da96c88f"
   elsif OS.linux?
     url "https://github.com/goniszewski/grimoire/releases/download/v1.1.0/little-imp-1.1.0-linux.tar.gz"
-    sha256 "8b903ee96aa5ea9fa2edcec223c969c10e5e2231b1bfe4e7ad442be31d295b0c"
+    sha256 "50429c64e2befeca1daca6d44a95d74f755f7be4a16ed869d68a80007809d340"
   end
 
   def install

--- a/scripts/homebrew-formula.test.ts
+++ b/scripts/homebrew-formula.test.ts
@@ -38,8 +38,8 @@ const releaseChecksumBaselines: Record<string, ReleaseChecksumBaseline> = {
     linux: "42cf4ea63bb31ea2380a0b3c8c4c65f7af943974ce1024dd9562a2484e343cff",
   },
   "1.1.0": {
-    macos: "f9435a3d956bf47aaa7b724319e49e41699b51d462d8474d91eaf5ca1f325cd2",
-    linux: "8b903ee96aa5ea9fa2edcec223c969c10e5e2231b1bfe4e7ad442be31d295b0c",
+    macos: "c68bc963602a79631c76df223b9cc4a3709a0d382c0b117288f27c72da96c88f",
+    linux: "50429c64e2befeca1daca6d44a95d74f755f7be4a16ed869d68a80007809d340",
   },
 };
 

--- a/scripts/installed-app-smoke.test.ts
+++ b/scripts/installed-app-smoke.test.ts
@@ -52,7 +52,7 @@ describe("installed-app smoke suite", () => {
     expect(releaseArchiveName("0.1.0-beta", "linux")).toBe("little-imp-0.1.0-beta-linux.tar.gz");
     expect(releaseArchiveName("0.1.0-beta", "macos")).toBe("little-imp-0.1.0-beta-macos.tar.gz");
     expect(defaultPublishedReleaseBaseUrl("0.1.0-beta")).toBe(
-      "https://github.com/goniszewski/little-imp/releases/download/v0.1.0-beta"
+      "https://github.com/goniszewski/grimoire/releases/download/v0.1.0-beta"
     );
     expect(() => defaultPublishedReleaseBaseUrl("../0.1.0-beta")).toThrow(
       "Release version contains unsupported characters"

--- a/scripts/installed-app-smoke.ts
+++ b/scripts/installed-app-smoke.ts
@@ -120,7 +120,7 @@ export function releaseArchiveName(version: string, platform: ReleasePlatform): 
 
 export function defaultPublishedReleaseBaseUrl(version: string): string {
   assertSafeReleaseVersion(version);
-  return `https://github.com/goniszewski/little-imp/releases/download/v${version}`;
+  return `https://github.com/goniszewski/grimoire/releases/download/v${version}`;
 }
 
 export function backupNameFromPath(path: string): string {


### PR DESCRIPTION
## Summary

- Point published installed-app smoke checks at the public `goniszewski/grimoire` release URL.
- Align the Homebrew formula and tracked test baselines with the freshly packaged `1.1.0` archive checksums.

## Validation

- `npm run check`
- `npx vitest run scripts/homebrew-formula.test.ts scripts/installed-app-smoke.test.ts`
- `npm run test:e2e`
- `bun run scripts/installed-app-smoke.ts`
- `npm run release:validate -- --require-signatures`
