### PR TITLE
feat: add Homebrew support and rename CLI to Grimoire

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,3 +71,17 @@ jobs:
           name: grimoire-demo-dist
           path: dist/
           if-no-files-found: error
+
+  homebrew:
+    name: Homebrew tap and install smoke test
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_ENV_HINTS: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate local tap and install formula
+        run: bash scripts/homebrew-smoke.sh

--- a/Formula/grimoire.rb
+++ b/Formula/grimoire.rb
@@ -21,6 +21,13 @@ class Grimoire < Formula
     cli_wrapper = <<~EOS
       #!/bin/bash
       set -euo pipefail
+      # Published archives may predate the CLI's package-manager guard.
+      case "${1:-} ${2:-}" in
+        "update install"|"update upgrade")
+          echo 'Homebrew-managed installations are updated with `brew upgrade grimoire`.' >&2
+          exit 2
+          ;;
+      esac
       export LITTLEIMP_PACKAGE_MANAGER="homebrew"
       exec "#{bun}" "#{opt_libexec}/daemon/src/cli.ts" "$@"
     EOS
@@ -85,7 +92,12 @@ class Grimoire < Formula
   end
 
   test do
-    assert_match version, shell_output("#{bin}/grimoire --help")
-    assert_match version, shell_output("#{bin}/littleimp --help")
+    update_actions = %w[install upgrade]
+    %w[grimoire littleimp].each do |command|
+      assert_match version.to_s, shell_output("#{bin}/#{command} --help")
+      update_actions.each do |action|
+        assert_match "brew upgrade grimoire", shell_output("#{bin}/#{command} update #{action} 2>&1", 2)
+      end
+    end
   end
 end

--- a/Formula/grimoire.rb
+++ b/Formula/grimoire.rb
@@ -3,25 +3,31 @@ class Grimoire < Formula
   homepage "https://github.com/goniszewski/grimoire"
   license "MIT"
 
-  depends_on "oven-sh/bun/bun"
+  depends_on "bun"
 
   if OS.mac?
     url "https://github.com/goniszewski/grimoire/releases/download/v1.1.0/little-imp-1.1.0-macos.tar.gz"
-    sha256 "c68bc963602a79631c76df223b9cc4a3709a0d382c0b117288f27c72da96c88f"
+    sha256 "98e96cc53bebf02265c86d2014bba0d9cf9978a7bc411d041cac86bef1ce8021"
   elsif OS.linux?
     url "https://github.com/goniszewski/grimoire/releases/download/v1.1.0/little-imp-1.1.0-linux.tar.gz"
-    sha256 "50429c64e2befeca1daca6d44a95d74f755f7be4a16ed869d68a80007809d340"
+    sha256 "793c416e22173c4c825f564487d5ae704db5d3bedb99553545f7f1dad83657d7"
   end
 
   def install
     libexec.install "daemon", "dist", "bin", "README.md", "VERSION", "RELEASE.json", "CHECKSUMS.sha256", "SIGNING.md"
-    system Formula["oven-sh/bun/bun"].opt_bin/"bun", "install", "--production", "--cwd", libexec/"daemon"
+    bun = formula_opt_bin("bun")/"bun"
+    system bun, "install", "--production", "--frozen-lockfile", "--cwd", libexec/"daemon"
 
-    (bin/"littleimp").write <<~EOS
+    cli_wrapper = <<~EOS
       #!/bin/bash
       set -euo pipefail
-      exec "#{Formula["oven-sh/bun/bun"].opt_bin}/bun" "#{opt_libexec}/daemon/src/cli.ts" "$@"
+      export LITTLEIMP_PACKAGE_MANAGER="homebrew"
+      exec "#{bun}" "#{opt_libexec}/daemon/src/cli.ts" "$@"
     EOS
+    (bin/"grimoire").write cli_wrapper
+    (bin/"littleimp").write cli_wrapper
+    (bin/"grimoire").chmod 0555
+    (bin/"littleimp").chmod 0555
 
     (bin/"littleimpd").write <<~EOS
       #!/bin/bash
@@ -33,8 +39,9 @@ class Grimoire < Formula
       export LOG_FORMAT="${LOG_FORMAT:-json}"
       mkdir -p "${DATA_DIR}/logs"
       cd "#{opt_libexec}/daemon"
-      exec "#{Formula["oven-sh/bun/bun"].opt_bin}/bun" run "#{opt_libexec}/daemon/src/index.ts"
+      exec "#{bun}" run "#{opt_libexec}/daemon/src/index.ts"
     EOS
+    (bin/"littleimpd").chmod 0555
   end
 
   def post_install
@@ -53,6 +60,17 @@ class Grimoire < Formula
     chmod 0600, env_path
   end
 
+  def caveats
+    <<~EOS
+      Start the Grimoire daemon with:
+        brew services start grimoire
+
+      Use `brew upgrade grimoire` to update this Homebrew installation.
+      Homebrew-managed data is stored under:
+        #{var}/little-imp
+    EOS
+  end
+
   service do
     run [opt_bin/"littleimpd"]
     working_dir opt_libexec/"daemon"
@@ -67,6 +85,7 @@ class Grimoire < Formula
   end
 
   test do
-    assert_match "littleimp #{version}", shell_output("#{bin}/littleimp --help")
+    assert_match version, shell_output("#{bin}/grimoire --help")
+    assert_match version, shell_output("#{bin}/littleimp --help")
   end
 end

--- a/README.md
+++ b/README.md
@@ -192,8 +192,12 @@ live install, service-lifecycle, and data-preservation checks are still
 pending. Once the `goniszewski/grimoire` tap is published, the intended user
 flow is:
 
+Current Homebrew releases require explicit trust for non-official taps, so
+trust only this formula:
+
 ```sh
 brew tap goniszewski/grimoire
+brew trust --formula goniszewski/grimoire/grimoire
 brew install grimoire
 brew services start grimoire
 ```
@@ -362,6 +366,16 @@ npm run test:daemon
 npm run test:e2e
 npm run build
 ```
+
+Homebrew-specific validation requires Homebrew and performs a disposable
+install through a local tap:
+
+```sh
+npm run test:homebrew
+```
+
+After the public tap is published, `npm run test:homebrew:published` exercises
+the one-argument `brew tap goniszewski/grimoire` path.
 
 Full local quality gate:
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ Grimoire is a local-first bookmark manager for people who save technical resourc
 
 > [!NOTE]
 > The current Grimoire application is a complete rewrite — a fresh start for the project. The legacy Grimoire (v0.5.x, SvelteKit-based) is preserved on the [`legacy/v0.x`](https://github.com/goniszewski/grimoire/tree/legacy/v0.x) branch.
-> Coming from v0.5.x? Grimoire 1.1.0 includes an **experimental** `littleimp migrate` tool for v0.5 SQLite data. See the [migration guide](./docs/migration.md) before applying it.
+> Coming from v0.5.x? Grimoire 1.1.0 includes an **experimental** `grimoire migrate` tool for v0.5 SQLite data. See the [migration guide](./docs/migration.md) before applying it.
 > Everything remains **local-first**, **private**, and **100% open source** under the MIT license.
+
+The current source and repackaged builds use `grimoire` as the primary CLI
+name; `littleimp` remains a compatibility alias. The already-published v1.1.0
+archive predates this rename and exposes `littleimp` when used directly.
 
 ## Contents
 
@@ -152,7 +156,8 @@ bookmark usable and expose retry/reprocess controls.
 
 The source installer copies daemon files, installs production dependencies,
 builds the frontend, writes a default config, registers the user service, and
-starts the daemon.
+starts the daemon. It installs `grimoire` under `~/.local/bin` and keeps
+`littleimp` there as a compatibility alias.
 
 ```sh
 cd daemon
@@ -182,9 +187,23 @@ cd daemon
 
 ### Homebrew (pending live validation)
 
-The repository includes a Homebrew formula, but public install, service
-lifecycle, and data-preservation checks have not passed against release assets.
-It is not a supported installation path yet.
+The Homebrew formula is prepared in the repository, but the public tap and
+live install, service-lifecycle, and data-preservation checks are still
+pending. Once the `goniszewski/grimoire` tap is published, the intended user
+flow is:
+
+```sh
+brew tap goniszewski/grimoire
+brew install grimoire
+brew services start grimoire
+```
+
+Use `brew upgrade grimoire` for Homebrew upgrades. Homebrew-managed data is
+kept under `$(brew --prefix)/var/little-imp`; it is separate from the native
+`~/.local/share/littleimp` directory and is not migrated automatically.
+
+Until those publication-gated checks pass, Homebrew is not a supported
+installation path.
 
 ## Data, Privacy, And Security
 
@@ -236,8 +255,9 @@ diagnostics, and portable settings backups.
 
 ## Backups And Restore
 
-Settings and the packaged `littleimp` CLI can create, verify, encrypt, and
-restore local backup snapshots. Each normal snapshot contains:
+Settings and the packaged `grimoire` CLI can create, verify, encrypt, and
+restore local backup snapshots. The legacy `littleimp` command remains
+available as a compatibility alias. Each normal snapshot contains:
 
 - `snapshot.db`
 - `manifest.json`
@@ -247,20 +267,20 @@ restore local backup snapshots. Each normal snapshot contains:
 CLI examples:
 
 ```sh
-littleimp backup create
-littleimp backup list
-littleimp backup verify --file ~/.local/share/littleimp/backups/BACKUP_NAME
-littleimp backup restore BACKUP_NAME --yes
+grimoire backup create
+grimoire backup list
+grimoire backup verify --file ~/.local/share/littleimp/backups/BACKUP_NAME
+grimoire backup restore BACKUP_NAME --yes
 ```
 
 Encrypted package examples:
 
 ```sh
 LITTLEIMP_BACKUP_PASSWORD='use-a-long-unique-password' \
-  littleimp backup create --encrypt --output ~/Desktop/little-imp-backup.enc
+  grimoire backup create --encrypt --output ~/Desktop/little-imp-backup.enc
 
 LITTLEIMP_BACKUP_PASSWORD='use-a-long-unique-password' \
-  littleimp backup verify --encrypted --file ~/Desktop/little-imp-backup.enc
+  grimoire backup verify --encrypted --file ~/Desktop/little-imp-backup.enc
 ```
 
 Restores verify checksums, create a rollback directory, replace local data, and
@@ -273,9 +293,9 @@ tags, and available local media into Grimoire 1.x. Start with `inspect`, review
 an `apply --dry-run`, then apply with `--yes`:
 
 ```sh
-littleimp migrate inspect --data-dir /path/to/grimoire/data
-littleimp migrate apply --data-dir /path/to/grimoire/data --owner YOUR_USERNAME --dry-run
-littleimp migrate apply --data-dir /path/to/grimoire/data --owner YOUR_USERNAME --yes
+grimoire migrate inspect --data-dir /path/to/grimoire/data
+grimoire migrate apply --data-dir /path/to/grimoire/data --owner YOUR_USERNAME --dry-run
+grimoire migrate apply --data-dir /path/to/grimoire/data --owner YOUR_USERNAME --yes
 ```
 
 See the complete [migration guide](./docs/migration.md) for archive inputs,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -112,10 +112,12 @@ other sites cannot frame the UI.
   before extraction.
 - Detached `.asc` signatures are verified when published or explicitly
   provided.
-- The packaged `littleimp update install` flow verifies checksums, verifies
+- The packaged `grimoire update install` flow verifies checksums, verifies
   optional detached signatures, rejects unsafe archive layouts, runs the native
   installer in upgrade mode, and confirms `/health` reports the upgraded
-  version.
+  version. The legacy `littleimp` alias has the same behavior for native
+  packaged installs; Homebrew-managed installs are upgraded with
+  `brew upgrade grimoire`.
 - The Homebrew formula uses the same release archives and verifies their
   published SHA-256 checksums.
 

--- a/daemon/install.sh
+++ b/daemon/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# install.sh — littleimpd installer
+# install.sh — Grimoire installer
 # Usage: ./install.sh [--uninstall] [--upgrade]
 set -euo pipefail
 
@@ -10,7 +10,8 @@ DATA_DIR="${HOME}/.local/share/littleimp"
 LOG_DIR="${DATA_DIR}/logs"
 FRONTEND_INSTALL_DIR="${DATA_DIR}/dist"
 CLI_BIN_DIR="${HOME}/.local/bin"
-CLI_BIN="${CLI_BIN_DIR}/littleimp"
+CLI_BIN="${CLI_BIN_DIR}/grimoire"
+LEGACY_CLI_BIN="${CLI_BIN_DIR}/littleimp"
 HEALTH_URL="http://127.0.0.1:3210/health"
 HEALTH_TIMEOUT=15
 BUN_MIN_MAJOR=1
@@ -95,7 +96,7 @@ install_daemon_files() {
     rm -f  "${INSTALL_DIR}/.env" 2>/dev/null || true
   fi
   info "Installing dependencies…"
-  (cd "${INSTALL_DIR}" && bun install --production)
+  (cd "${INSTALL_DIR}" && bun install --production --frozen-lockfile)
   info "Daemon files installed"
 }
 
@@ -137,20 +138,26 @@ install_frontend_files() {
   info "Frontend files installed"
 }
 
-install_cli() {
-  info "Installing CLI command to ${CLI_BIN}…"
-  mkdir -p "${CLI_BIN_DIR}"
+write_cli_wrapper() {
+  local cli_path="$1"
   {
     printf '#!/usr/bin/env bash\n'
     printf 'exec %q %q "$@"\n' "${BUN_PATH}" "${INSTALL_DIR}/src/cli.ts"
-  } > "${CLI_BIN}"
-  chmod +x "${CLI_BIN}"
+  } > "${cli_path}"
+  chmod +x "${cli_path}"
+}
+
+install_cli() {
+  info "Installing CLI commands to ${CLI_BIN} and ${LEGACY_CLI_BIN}…"
+  mkdir -p "${CLI_BIN_DIR}"
+  write_cli_wrapper "${CLI_BIN}"
+  write_cli_wrapper "${LEGACY_CLI_BIN}"
 
   case ":${PATH}:" in
     *":${CLI_BIN_DIR}:"*) ;;
-    *) warn "${CLI_BIN_DIR} is not on PATH. Add it to your shell profile to run 'littleimp' directly." ;;
+    *) warn "${CLI_BIN_DIR} is not on PATH. Add it to your shell profile to run 'grimoire' directly." ;;
   esac
-  info "CLI installed: ${CLI_BIN}"
+  info "CLI installed: ${CLI_BIN} (legacy alias: ${LEGACY_CLI_BIN})"
 }
 
 create_config_dir() {
@@ -253,7 +260,11 @@ wait_for_health() {
 
 print_success() {
   local mode="${1:-install}"
-  printf '\n\033[32m✓ littleimpd %sd and running!\033[0m\n' "${mode}"
+  local status_word="installed"
+  if [[ "${mode}" == "upgrade" ]]; then
+    status_word="upgraded"
+  fi
+  printf '\n\033[32m✓ Grimoire %s and running!\033[0m\n' "${status_word}"
   printf '  Health: %s\n' "${HEALTH_URL}"
   printf '  Data:   %s\n' "${DATA_DIR}"
   printf '  Logs:   %s\n' "${LOG_DIR}"
@@ -267,7 +278,7 @@ print_success() {
 # ---------- uninstall ----------
 uninstall() {
   local purge="${1:-}"
-  info "Uninstalling littleimpd…"
+  info "Uninstalling Grimoire (littleimpd)…"
   local os
   os="$(detect_os)"
   if [[ "${os}" == "macos" ]]; then
@@ -287,10 +298,13 @@ uninstall() {
     rm -rf "${INSTALL_DIR}"
     info "Daemon files removed from ${INSTALL_DIR}"
   fi
-  if [[ -f "${CLI_BIN}" ]] && grep -Fq "${INSTALL_DIR}/src/cli.ts" "${CLI_BIN}" 2>/dev/null; then
-    rm -f "${CLI_BIN}"
-    info "CLI command removed: ${CLI_BIN}"
-  fi
+  local cli_path
+  for cli_path in "${CLI_BIN}" "${LEGACY_CLI_BIN}"; do
+    if [[ -f "${cli_path}" ]] && grep -Fq "${INSTALL_DIR}/src/cli.ts" "${cli_path}" 2>/dev/null; then
+      rm -f "${cli_path}"
+      info "CLI command removed: ${cli_path}"
+    fi
+  done
   if [[ "${purge}" == "--purge" ]]; then
     if [[ -d "${DATA_DIR}" ]]; then
       rm -rf "${DATA_DIR}"
@@ -298,7 +312,8 @@ uninstall() {
     fi
   else
     info "Data preserved at: ${DATA_DIR}"
-    info "To also remove data, run: $0 --uninstall --purge"
+    info "To also remove data later, rerun the original source or release installer with:"
+    info "  ./install.sh --uninstall --purge"
   fi
 }
 
@@ -316,11 +331,11 @@ main() {
       ;;
     --help|-h)
       printf 'Usage: %s [--upgrade] [--uninstall [--purge]]\n' "$(basename "$0")"
-      printf '  (no flags)         Fresh install of littleimpd\n'
+      printf '  (no flags)         Fresh install of Grimoire (daemon: littleimpd)\n'
       printf '  --upgrade          Stop daemon, update files, restart\n'
       printf '  --uninstall        Stop and remove daemon and files (data preserved)\n'
       printf '  --uninstall --purge  Also delete all data at %s\n' "${DATA_DIR}"
-      printf '\nInstalls the CLI command at %s\n' "${CLI_BIN}"
+      printf '\nInstalls CLI commands at %s and %s\n' "${CLI_BIN}" "${LEGACY_CLI_BIN}"
       exit 0
       ;;
     "")

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "bin": {
+    "grimoire": "./src/cli.ts",
     "littleimp": "./src/cli.ts"
   },
   "scripts": {

--- a/daemon/src/cli.ts
+++ b/daemon/src/cli.ts
@@ -376,30 +376,30 @@ function formatRollbackGuidance(lines: string[]): string {
 
 function usage(): string {
   return [
-    `littleimp ${APP_VERSION}`,
+    `grimoire ${APP_VERSION}`,
     "",
     "Usage:",
-    "  littleimp update check [--channel stable|beta] [--source URL] [--json]",
-    "  littleimp update install [--version VERSION] [--release-base-url URL] [--channel stable|beta] [--source URL] [--json] [--allow-unsigned]",
-    "  littleimp update install --archive FILE --checksum FILE [--signature FILE] [--json] [--allow-unsigned]",
-    "  littleimp backup create [--json] [--daemon-url URL]",
-    "  littleimp backup create --encrypt --output FILE [--json] [--daemon-url URL] [--password-file FILE]",
-    "  littleimp backup list [--include-remote] [--json] [--daemon-url URL]",
-    "  littleimp backup restore <name> --yes [--json] [--daemon-url URL]",
-    "  littleimp backup restore --remote-key <key> --yes [--json] [--daemon-url URL]",
-    "  littleimp backup restore --encrypted-file FILE --yes [--json] [--daemon-url URL] [--password-file FILE]",
-    "  littleimp backup verify --file <snapshot-directory> [--json]",
-    "  littleimp backup verify --encrypted --file FILE [--json] [--password-file FILE]",
-    "  littleimp diagnostics [--json] [--daemon-url URL]",
+    "  grimoire update check [--channel stable|beta] [--source URL] [--json]",
+    "  grimoire update install [--version VERSION] [--release-base-url URL] [--channel stable|beta] [--source URL] [--json] [--allow-unsigned]",
+    "  grimoire update install --archive FILE --checksum FILE [--signature FILE] [--json] [--allow-unsigned]",
+    "  grimoire backup create [--json] [--daemon-url URL]",
+    "  grimoire backup create --encrypt --output FILE [--json] [--daemon-url URL] [--password-file FILE]",
+    "  grimoire backup list [--include-remote] [--json] [--daemon-url URL]",
+    "  grimoire backup restore <name> --yes [--json] [--daemon-url URL]",
+    "  grimoire backup restore --remote-key <key> --yes [--json] [--daemon-url URL]",
+    "  grimoire backup restore --encrypted-file FILE --yes [--json] [--daemon-url URL] [--password-file FILE]",
+    "  grimoire backup verify --file <snapshot-directory> [--json]",
+    "  grimoire backup verify --encrypted --file FILE [--json] [--password-file FILE]",
+    "  grimoire diagnostics [--json] [--daemon-url URL]",
     "",
     "Migration commands (experimental; v0.5 SQLite only):",
-    "  littleimp migrate inspect --data-dir <v0.5-data-dir> [--json] [--daemon-url URL]",
-    "  littleimp migrate inspect --db <db.sqlite> [--uploads-dir DIR] [--json] [--daemon-url URL]",
-    "  littleimp migrate inspect --archive <data.zip|tar.gz|…> [--json] [--daemon-url URL]",
-    "  littleimp migrate apply --data-dir <v0.5-data-dir> --yes [--owner USER] [--password|--password-file FILE] [--merge] [--json] [--daemon-url URL]",
-    "  littleimp migrate apply --db <db.sqlite> --yes [--uploads-dir DIR] [--owner USER] [--password|--password-file FILE] [--merge] [--json] [--daemon-url URL]",
-    "  littleimp migrate apply --archive <data.zip|tar.gz|…> --yes [--owner USER] [--password|--password-file FILE] [--merge] [--json] [--daemon-url URL]",
-    "  littleimp migrate apply --data-dir <v0.5-data-dir> --dry-run [--owner USER] [--merge] [--json] [--daemon-url URL]",
+    "  grimoire migrate inspect --data-dir <v0.5-data-dir> [--json] [--daemon-url URL]",
+    "  grimoire migrate inspect --db <db.sqlite> [--uploads-dir DIR] [--json] [--daemon-url URL]",
+    "  grimoire migrate inspect --archive <data.zip|tar.gz|…> [--json] [--daemon-url URL]",
+    "  grimoire migrate apply --data-dir <v0.5-data-dir> --yes [--owner USER] [--password|--password-file FILE] [--merge] [--json] [--daemon-url URL]",
+    "  grimoire migrate apply --db <db.sqlite> --yes [--uploads-dir DIR] [--owner USER] [--password|--password-file FILE] [--merge] [--json] [--daemon-url URL]",
+    "  grimoire migrate apply --archive <data.zip|tar.gz|…> --yes [--owner USER] [--password|--password-file FILE] [--merge] [--json] [--daemon-url URL]",
+    "  grimoire migrate apply --data-dir <v0.5-data-dir> --dry-run [--owner USER] [--merge] [--json] [--daemon-url URL]",
     "",
     "Environment:",
     "  LITTLEIMP_DAEMON_URL  Defaults to http://127.0.0.1:3210",
@@ -670,6 +670,13 @@ async function handleUpdateInstallCommand(
     ],
   });
   assertNoPositionals(parsed, command, "update");
+
+  if (io.env.LITTLEIMP_PACKAGE_MANAGER === "homebrew") {
+    throw new CliError(
+      "Homebrew-managed installations are updated with `brew upgrade grimoire`; do not use the CLI self-update command.",
+      2
+    );
+  }
 
   const archive = parsed.values.get("--archive");
   const checksum = parsed.values.get("--checksum");

--- a/daemon/src/test/cli-update.test.ts
+++ b/daemon/src/test/cli-update.test.ts
@@ -313,6 +313,19 @@ describe("littleimp update CLI", () => {
     });
   });
 
+  it("directs Homebrew-managed installations to brew for upgrades", async () => {
+    const harness = makeUpgradeHarness("1.2.0", undefined, {
+      LITTLEIMP_PACKAGE_MANAGER: "homebrew",
+    });
+
+    const code = await harness.run(["update", "install"]);
+
+    expect(code).toBe(2);
+    expect(harness.stderr.join("\n")).toContain("brew upgrade grimoire");
+    expect(harness.spawnCalls).toHaveLength(0);
+    expect(harness.fetchCalls).toHaveLength(0);
+  });
+
   it("rejects unexpected positional arguments with an update-specific error", async () => {
     const harness = makeUpdateHarness([]);
 

--- a/daemon/src/test/integration/installer-static-frontend.test.ts
+++ b/daemon/src/test/integration/installer-static-frontend.test.ts
@@ -189,6 +189,22 @@ describe("install.sh static frontend install", () => {
     }
   });
 
+  it("installs the primary and legacy CLI wrappers", async () => {
+    const result = await runInstallerFixture({ frontend: "prebuilt" });
+
+    try {
+      const cliDir = join(result.homeDir, ".local", "bin");
+      expect(result.stdout).toContain("Grimoire installed and running!");
+      for (const command of ["grimoire", "littleimp"]) {
+        const cliPath = join(cliDir, command);
+        expect(existsSync(cliPath)).toBe(true);
+        await expect(readFile(cliPath, "utf8")).resolves.toContain("daemon/src/cli.ts");
+      }
+    } finally {
+      await rm(result.tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("installs a prebuilt frontend bundle without rebuilding it", async () => {
     const result = await runInstallerFixture({ frontend: "prebuilt" });
 

--- a/docs/03-using-grimoire.md
+++ b/docs/03-using-grimoire.md
@@ -65,7 +65,11 @@ You can also import a Netscape/HTML bookmark export from your browser, and expor
 
 ## Backups
 
-From Settings or the `littleimp` CLI you can create, list, verify, and restore local snapshots. Encrypted packages and optional scheduled/S3 targets are available in Settings when configured. Restores verify checksums and create a rollback copy first.
+From Settings or the `grimoire` CLI you can create, list, verify, and restore local snapshots. The legacy `littleimp` command remains available as a compatibility alias. Encrypted packages and optional scheduled/S3 targets are available in Settings when configured. Restores verify checksums and create a rollback copy first.
+
+The already-published v1.1.0 archive predates the CLI rename and uses
+`littleimp` when invoked directly; current source installs and future
+repackaged releases use `grimoire`.
 
 ## Local integrations
 

--- a/docs/04-development.md
+++ b/docs/04-development.md
@@ -50,6 +50,16 @@ npm run build
 npm run check
 ```
 
+Homebrew-specific validation requires Homebrew and performs a disposable
+install through a local tap:
+
+```sh
+npm run test:homebrew
+```
+
+After the public tap is published, `npm run test:homebrew:published` exercises
+the one-argument `brew tap goniszewski/grimoire` path.
+
 If tooling is missing in a constrained environment:
 
 ```sh

--- a/docs/05-install-without-docker.md
+++ b/docs/05-install-without-docker.md
@@ -63,10 +63,11 @@ cd daemon
 
 For day-to-day coding, prefer [Development](./04-development.md) (`npm run daemon:dev` + `npm run dev`) instead of reinstalling.
 
-The Homebrew formula is prepared in the repo, but live Homebrew install is not a supported user path until the public tap and published release assets are validated. The intended command after publication is:
+The Homebrew formula is prepared in the repo, but live Homebrew install is not a supported user path until the public tap and published release assets are validated. Current Homebrew releases require explicit trust for non-official taps, so trust only this formula. The intended command after publication is:
 
 ```sh
 brew tap goniszewski/grimoire
+brew trust --formula goniszewski/grimoire/grimoire
 brew install grimoire
 brew services start grimoire
 ```

--- a/docs/05-install-without-docker.md
+++ b/docs/05-install-without-docker.md
@@ -8,7 +8,11 @@ Native install on macOS or Linux. There is no native Windows installer; use Dock
 - A git clone of this repository (or an unpacked release that includes the frontend build sources)
 - macOS or Linux
 
-The installer installs production dependencies, builds the frontend when possible, and registers a user service. You do not need to run `npm install` first.
+The installer installs production dependencies, builds the frontend when possible, and registers a user service. It installs the `grimoire` CLI under `~/.local/bin` and keeps `littleimp` as a compatibility alias. You do not need to run `npm install` first.
+
+The published v1.1.0 archive predates this CLI rename and exposes `littleimp`
+when used directly. The `grimoire` name is available from the current source
+installer and future repackaged releases.
 
 ## Install
 
@@ -59,4 +63,13 @@ cd daemon
 
 For day-to-day coding, prefer [Development](./04-development.md) (`npm run daemon:dev` + `npm run dev`) instead of reinstalling.
 
-Homebrew formula files may exist in the repo, but live Homebrew install is not a supported user path until it is validated against published release assets.
+The Homebrew formula is prepared in the repo, but live Homebrew install is not a supported user path until the public tap and published release assets are validated. The intended command after publication is:
+
+```sh
+brew tap goniszewski/grimoire
+brew install grimoire
+brew services start grimoire
+```
+
+Use `brew upgrade grimoire` for Homebrew upgrades. Homebrew stores its data
+under `$(brew --prefix)/var/little-imp`, separately from native-install data.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -3,6 +3,9 @@
 Grimoire diagnostics are generated locally and are only shared when the user
 chooses to copy, export, or send them. They are not telemetry.
 
+Current source installs and future repackaged releases use the `grimoire` CLI;
+the already-published v1.1.0 archive uses `littleimp` when invoked directly.
+
 ## Generate diagnostics
 
 From Settings:
@@ -13,9 +16,9 @@ From Settings:
 From the packaged CLI:
 
 ```sh
-littleimp diagnostics
-littleimp diagnostics --json
-littleimp diagnostics --daemon-url http://127.0.0.1:3210 --json
+grimoire diagnostics
+grimoire diagnostics --json
+grimoire diagnostics --daemon-url http://127.0.0.1:3210 --json
 ```
 
 From the daemon API:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,11 +42,11 @@ Migration is **non-destructive** for your v0.5 data and **additive** for Grimoir
 Run the [migration guide](./migration.md) for the complete workflow:
 
 ```sh
-littleimp migrate inspect --data-dir /path/to/grimoire/data
-littleimp migrate apply --data-dir /path/to/grimoire/data --owner YOUR_USERNAME --dry-run
-littleimp migrate apply --data-dir /path/to/grimoire/data --owner YOUR_USERNAME --yes
+grimoire migrate inspect --data-dir /path/to/grimoire/data
+grimoire migrate apply --data-dir /path/to/grimoire/data --owner YOUR_USERNAME --dry-run
+grimoire migrate apply --data-dir /path/to/grimoire/data --owner YOUR_USERNAME --yes
 # Or pack the data folder first:
-littleimp migrate apply --archive /path/to/grimoire-data.tar.gz --owner YOUR_USERNAME --yes
+grimoire migrate apply --archive /path/to/grimoire-data.tar.gz --owner YOUR_USERNAME --yes
 ```
 
 
@@ -60,8 +60,11 @@ era backups are not supported. See the [migration API reference](https://github.
 ## How do I upgrade?
 
 For source or unpacked release installs, run `daemon/install.sh --upgrade`.
-Packaged installs can use `littleimp update install` once a reachable release
-source is configured. Settings can also check for update availability.
+Native packaged installs can use `grimoire update install` once a reachable
+release source is configured; `littleimp` remains a compatibility alias.
+Homebrew installations should use `brew upgrade grimoire`. Settings can also
+check for update availability. The already-published v1.1.0 archive predates
+the rename and uses `littleimp` as its direct archive command.
 
 ## Does it work on Windows?
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -5,7 +5,12 @@ owner's library from the legacy Grimoire v0.5 SQLite application into a local
 Grimoire 1.x library.
 
 > This guide describes the v0.5 migrator in the 1.1.0 release line. Older
-> development builds may not include the `littleimp migrate` command.
+> development builds may not include the `grimoire migrate` command.
+
+The already-published v1.1.0 archive predates the CLI rename and exposes the
+same migrator as `littleimp migrate`. Current source installs and future
+repackaged releases use `grimoire migrate`; `littleimp` remains a compatibility
+alias.
 
 The migrator accepts a v0.5 SQLite data directory, a `db.sqlite` file, or an
 archive containing that data. It does not support PocketBase-era backups from
@@ -24,7 +29,7 @@ the older 0.3.x line.
    curl http://127.0.0.1:3210/health
    ```
 
-4. Run the `littleimp` CLI from the same Grimoire installation as the daemon.
+4. Run the `grimoire` CLI from the same Grimoire installation as the daemon.
 
 If you are working from a source checkout rather than a packaged install, run
 the CLI with `bun run cli --` from the `daemon/` directory.
@@ -47,17 +52,17 @@ raw PocketBase backup, or an unrelated SQLite database is rejected.
 Start by listing the source owners and record counts:
 
 ```sh
-littleimp migrate inspect --data-dir /path/to/grimoire/data
+grimoire migrate inspect --data-dir /path/to/grimoire/data
 ```
 
 For a database file or archive:
 
 ```sh
-littleimp migrate inspect \
+grimoire migrate inspect \
   --db /path/to/grimoire/data/db.sqlite \
   --uploads-dir /path/to/grimoire/data/user-uploads
 
-littleimp migrate inspect --archive /path/to/grimoire-data.tar.gz
+grimoire migrate inspect --archive /path/to/grimoire-data.tar.gz
 ```
 
 Inspect is read-only. It reports the number of users, bookmarks, categories,
@@ -72,7 +77,7 @@ or numeric v0.5 user ID. Only the selected owner's library is imported.
 Use the same source and owner for a no-write preview:
 
 ```sh
-littleimp migrate apply \
+grimoire migrate apply \
   --data-dir /path/to/grimoire/data \
   --owner YOUR_USERNAME \
   --dry-run
@@ -86,7 +91,7 @@ the planned counts and warnings before applying. It does not require `--yes`.
 When the preview is correct, apply it explicitly:
 
 ```sh
-littleimp migrate apply \
+grimoire migrate apply \
   --data-dir /path/to/grimoire/data \
   --owner YOUR_USERNAME \
   --yes
@@ -96,7 +101,7 @@ littleimp migrate apply \
 archive form is equivalent:
 
 ```sh
-littleimp migrate apply \
+grimoire migrate apply \
   --archive /path/to/grimoire-data.tar.gz \
   --owner YOUR_USERNAME \
   --yes
@@ -116,7 +121,7 @@ Prefer a password file or environment variable over putting a password in
 shell history:
 
 ```sh
-littleimp migrate apply \
+grimoire migrate apply \
   --data-dir /path/to/grimoire/data \
   --owner YOUR_USERNAME \
   --password-file /path/to/v05-password.txt \
@@ -125,7 +130,7 @@ littleimp migrate apply \
 
 ```sh
 LITTLEIMP_MIGRATE_PASSWORD='your-v05-password' \
-  littleimp migrate apply \
+  grimoire migrate apply \
     --data-dir /path/to/grimoire/data \
     --owner YOUR_USERNAME \
     --yes

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "package:release": "bun run scripts/package-release.ts",
     "release:validate": "bun run scripts/release-artifacts-validator.ts",
     "installer:matrix:linux": "bash scripts/validate-linux-installer-matrix.sh",
+    "test:homebrew": "bash scripts/homebrew-smoke.sh",
+    "test:homebrew:published": "bash scripts/homebrew-smoke.sh published",
     "test:e2e:installed": "npm run package:release && bun run scripts/installed-app-smoke.ts",
     "test:e2e:installed:published": "bun run scripts/installed-app-smoke.ts --source published --require-signature",
     "docker:build": "docker build -t grimoire .",

--- a/scripts/homebrew-formula.test.ts
+++ b/scripts/homebrew-formula.test.ts
@@ -38,8 +38,8 @@ const releaseChecksumBaselines: Record<string, ReleaseChecksumBaseline> = {
     linux: "42cf4ea63bb31ea2380a0b3c8c4c65f7af943974ce1024dd9562a2484e343cff",
   },
   "1.1.0": {
-    macos: "c68bc963602a79631c76df223b9cc4a3709a0d382c0b117288f27c72da96c88f",
-    linux: "50429c64e2befeca1daca6d44a95d74f755f7be4a16ed869d68a80007809d340",
+    macos: "98e96cc53bebf02265c86d2014bba0d9cf9978a7bc411d041cac86bef1ce8021",
+    linux: "793c416e22173c4c825f564487d5ae704db5d3bedb99553545f7f1dad83657d7",
   },
 };
 
@@ -110,15 +110,24 @@ describe("Homebrew formula packaging", () => {
       expect(sha256Match?.[1]).toBe(expectedChecksums[platform]);
     }
 
-    expect(formula).toContain('depends_on "oven-sh/bun/bun"');
+    expect(formula).toContain('depends_on "bun"');
+    expect(formula).not.toContain('depends_on "oven-sh/bun/bun"');
     expect(formula).toContain('libexec.install "daemon", "dist"');
-    expect(formula).toContain('"install", "--production", "--cwd", libexec/"daemon"');
+    expect(formula).toContain('"install", "--production", "--frozen-lockfile", "--cwd", libexec/"daemon"');
+    expect(formula).toContain('formula_opt_bin("bun")');
+    expect(formula).toContain('LITTLEIMP_PACKAGE_MANAGER="homebrew"');
+    expect(formula).toContain('(bin/"grimoire").write');
     expect(formula).toContain('(bin/"littleimp").write');
+    expect(formula).toContain('(bin/"grimoire").chmod 0555');
+    expect(formula).toContain('(bin/"littleimp").chmod 0555');
     expect(formula).toContain('(bin/"littleimpd").write');
+    expect(formula).toContain('(bin/"littleimpd").chmod 0555');
     expect(formula).toContain("service do");
     expect(formula).toContain("keep_alive true");
     expect(formula).toMatch(/HOST:\s+"127\.0\.0\.1"/);
     expect(formula).toMatch(/PORT:\s+"3210"/);
+    expect(formula).toContain("brew services start grimoire");
+    expect(formula).toContain("brew upgrade grimoire");
     expect(formula).not.toMatch(/git clone|npm run build|bun run build|system ".*daemon\/install\.sh/);
   });
 
@@ -126,7 +135,7 @@ describe("Homebrew formula packaging", () => {
     const readme = readProjectFile("README.md");
 
     expect(readme).toContain("### Homebrew (pending live validation)");
-    expect(readme).toContain("not a supported installation path yet");
+    expect(readme).toContain("Homebrew is not a supported");
     expect(readme).not.toContain("brew install little-imp");
     expect(readme).not.toContain("brew services start little-imp");
   });

--- a/scripts/homebrew-formula.test.ts
+++ b/scripts/homebrew-formula.test.ts
@@ -1,4 +1,6 @@
-import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -95,6 +97,47 @@ function formulaSnippetAfter(formula: string, expectedLine: string): string {
 }
 
 describe("Homebrew formula packaging", () => {
+  it("blocks native upgrades before invoking an older runtime and forwards other commands unchanged", () => {
+    const root = mkdtempSync(join(tmpdir(), "grimoire-formula-"));
+    try {
+      const runtime = join(root, "old bun");
+      // Stand in for an older archive that ignores LITTLEIMP_PACKAGE_MANAGER.
+      writeFileSync(runtime, '#!/bin/bash\nprintf "%s\\n" "$LITTLEIMP_PACKAGE_MANAGER" "$@"\n', { mode: 0o755 });
+      const formula = readFileSync(formulaPath, "utf8");
+      const wrapper = formula.match(/cli_wrapper = <<~EOS\n([\s\S]*?)^\s*EOS/m)?.[1];
+      expect(wrapper).toBeDefined();
+      const cliPath = join(root, "old release", "daemon", "src", "cli.ts");
+      const contents = wrapper!
+        .replace(/^ {6}/gm, "")
+        .replaceAll("#{bun}", runtime)
+        .replaceAll("#{opt_libexec}", join(root, "old release"));
+
+      for (const command of ["grimoire", "littleimp"]) {
+        const executable = join(root, command);
+        writeFileSync(executable, contents, { mode: 0o755 });
+        for (const action of ["install", "upgrade"]) {
+          for (const options of [[], ["--archive", "missing.tar.gz", "--checksum", "missing.sha256", "--json"]]) {
+            const result = spawnSync(executable, ["update", action, ...options], { encoding: "utf8" });
+            expect(result.error).toBeUndefined();
+            expect(result.status).toBe(2);
+            expect(result.stderr).toContain("brew upgrade grimoire");
+            expect(result.stdout).toBe("");
+          }
+        }
+
+        for (const args of [[], ["--help"], ["update", "check", "--json"], ["backup", "verify", "--file", "path with spaces", ""]]) {
+          const result = spawnSync(executable, args, { encoding: "utf8" });
+          expect(result.error).toBeUndefined();
+          expect(result.status).toBe(0);
+          expect(result.stderr).toBe("");
+          expect(result.stdout).toBe(["homebrew", cliPath, ...args, ""].join("\n"));
+        }
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("installs the current release archives by pinned checksum instead of rebuilding from source", () => {
     const version = packageVersion();
     const expectedChecksums = expectedReleaseChecksums(version);

--- a/scripts/homebrew-formula.test.ts
+++ b/scripts/homebrew-formula.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 type PackageJson = {
   version: string;
+  scripts?: Record<string, string>;
 };
 
 const platforms = ["macos", "linux"] as const;
@@ -133,10 +134,19 @@ describe("Homebrew formula packaging", () => {
 
   it("documents Homebrew as a pending path until live validation passes", () => {
     const readme = readProjectFile("README.md");
+    const packageJson = JSON.parse(readProjectFile("package.json")) as PackageJson;
 
     expect(readme).toContain("### Homebrew (pending live validation)");
     expect(readme).toContain("Homebrew is not a supported");
+    expect(readme).toContain("brew trust --formula goniszewski/grimoire/grimoire");
     expect(readme).not.toContain("brew install little-imp");
     expect(readme).not.toContain("brew services start little-imp");
+
+    const installGuide = readProjectFile("docs/05-install-without-docker.md");
+    expect(installGuide).toContain("brew trust --formula goniszewski/grimoire/grimoire");
+    expect(packageJson.scripts?.["test:homebrew"]).toBe("bash scripts/homebrew-smoke.sh");
+    expect(packageJson.scripts?.["test:homebrew:published"]).toBe(
+      "bash scripts/homebrew-smoke.sh published"
+    );
   });
 });

--- a/scripts/homebrew-smoke.sh
+++ b/scripts/homebrew-smoke.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="${1:-local}"
+TAP_NAME="${HOMEBREW_TEST_TAP_NAME:-goniszewski/grimoire}"
+FORMULA_NAME="grimoire"
+
+export HOMEBREW_NO_AUTO_UPDATE="${HOMEBREW_NO_AUTO_UPDATE:-1}"
+export HOMEBREW_NO_ENV_HINTS="${HOMEBREW_NO_ENV_HINTS:-1}"
+export HOMEBREW_NO_INSTALL_CLEANUP="${HOMEBREW_NO_INSTALL_CLEANUP:-1}"
+
+case "${MODE}" in
+  local|published)
+    ;;
+  *)
+    printf 'Usage: %s [local|published]\n' "${BASH_SOURCE[0]}" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v brew >/dev/null 2>&1; then
+  printf 'Homebrew smoke test requires brew on PATH.\n' >&2
+  exit 1
+fi
+
+if curl --fail --silent http://127.0.0.1:3210/health >/dev/null 2>&1; then
+  printf 'Homebrew smoke test requires port 3210 to be unused. Stop the existing daemon first.\n' >&2
+  exit 1
+fi
+
+# Homebrew 6 requires explicit trust for non-official taps. Keep that test-only
+# trust entry out of the developer's normal Homebrew configuration.
+homebrew_config_dir="$(mktemp -d)"
+export XDG_CONFIG_HOME="${homebrew_config_dir}"
+
+tap_was_present=false
+if brew tap | grep -Fxq "${TAP_NAME}"; then
+  tap_was_present=true
+fi
+
+if brew list --formula "${FORMULA_NAME}" >/dev/null 2>&1; then
+  printf 'Refusing to replace an existing Homebrew installation: %s\n' "${FORMULA_NAME}" >&2
+  rm -rf -- "${homebrew_config_dir}"
+  exit 1
+fi
+
+brew_prefix="$(brew --prefix)"
+data_dir="${brew_prefix}/var/little-imp"
+data_dir_was_present=false
+if [[ -e "${data_dir}" ]]; then
+  data_dir_was_present=true
+fi
+
+tap_added=false
+formula_installed=false
+service_started=false
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT
+
+  if [[ "${service_started}" == true ]]; then
+    brew services stop "${FORMULA_NAME}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ "${formula_installed}" == true ]]; then
+    brew uninstall --force "${FORMULA_NAME}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ "${tap_added}" == true ]]; then
+    brew untap --force "${TAP_NAME}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ "${data_dir_was_present}" == false && -e "${data_dir}" ]]; then
+    rm -rf -- "${data_dir}"
+  fi
+
+  rm -rf -- "${homebrew_config_dir}"
+  exit "${exit_code}"
+}
+
+trap cleanup EXIT
+
+if [[ "${data_dir_was_present}" == true ]]; then
+  printf 'Refusing to use an existing Homebrew data directory: %s\n' "${data_dir}" >&2
+  exit 1
+fi
+
+printf '==> Checking Homebrew formula style\n'
+brew style "${PROJECT_ROOT}/Formula/grimoire.rb"
+
+if [[ "${MODE}" == "local" && "${tap_was_present}" == true ]]; then
+  printf 'Refusing to reuse existing tap %s for a local smoke test. Untap it first or set HOMEBREW_TEST_TAP_NAME.\n' "${TAP_NAME}" >&2
+  exit 1
+fi
+
+if [[ "${tap_was_present}" == false ]]; then
+  tap_added=true
+  if [[ "${MODE}" == "local" ]]; then
+    tap_source="${HOMEBREW_TAP_URL:-${PROJECT_ROOT}}"
+    printf '==> Tapping local checkout as %s\n' "${TAP_NAME}"
+    brew tap "${TAP_NAME}" "${tap_source}"
+  elif [[ -n "${HOMEBREW_TAP_URL:-}" ]]; then
+    printf '==> Tapping %s from %s\n' "${TAP_NAME}" "${HOMEBREW_TAP_URL}"
+    brew tap "${TAP_NAME}" "${HOMEBREW_TAP_URL}"
+  else
+    printf '==> Tapping published GitHub tap %s\n' "${TAP_NAME}"
+    brew tap "${TAP_NAME}"
+  fi
+else
+  printf '==> Using existing tap %s\n' "${TAP_NAME}"
+fi
+
+if brew trust --help >/dev/null 2>&1; then
+  printf '==> Trusting only %s\n' "${TAP_NAME}/${FORMULA_NAME}"
+  brew trust --formula "${TAP_NAME}/${FORMULA_NAME}"
+else
+  printf '==> Homebrew has no tap-trust command; continuing without explicit trust\n'
+fi
+
+printf '==> Auditing %s\n' "${TAP_NAME}/${FORMULA_NAME}"
+brew audit --formula --strict --online "${TAP_NAME}/${FORMULA_NAME}"
+
+printf '==> Installing unqualified formula: brew install %s\n' "${FORMULA_NAME}"
+formula_installed=true
+brew install "${FORMULA_NAME}"
+
+formula_prefix="$(brew --prefix "${FORMULA_NAME}")"
+test -x "${formula_prefix}/bin/grimoire"
+test -x "${formula_prefix}/bin/littleimp"
+test -x "${formula_prefix}/bin/littleimpd"
+
+printf '==> Running Homebrew formula test\n'
+brew test "${TAP_NAME}/${FORMULA_NAME}"
+
+printf '==> Starting Homebrew service\n'
+service_started=true
+brew services start "${FORMULA_NAME}"
+
+health_ok=false
+for _ in $(seq 1 30); do
+  if curl --fail --silent http://127.0.0.1:3210/health >/dev/null 2>&1; then
+    health_ok=true
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${health_ok}" != true ]]; then
+  brew services list || true
+  cat "${data_dir}/logs/daemon.error.log" 2>/dev/null || true
+  printf 'Homebrew service did not become healthy.\n' >&2
+  exit 1
+fi
+
+test -f "${data_dir}/.env"
+test -d "${data_dir}/logs"
+
+printf '==> Stopping Homebrew service\n'
+brew services stop "${FORMULA_NAME}"
+service_started=false
+
+printf 'Homebrew %s smoke test passed for %s.\n' "${MODE}" "${TAP_NAME}/${FORMULA_NAME}"

--- a/scripts/installed-app-smoke.test.ts
+++ b/scripts/installed-app-smoke.test.ts
@@ -197,9 +197,12 @@ describe("installed-app smoke suite", () => {
       "GET /settings",
       "POST /backup",
       "POST /restore",
-      "littleimp update check",
+      "with its native installer",
+      "grimoire CLI and littleimp compatibility alias",
+      "grimoire update check",
       "data survives upgrade",
       "uninstall without purge",
+      "Native uninstall",
       "daemon.log",
     ]) {
       expect(smokeRunner).toContain(expected);

--- a/scripts/installed-app-smoke.ts
+++ b/scripts/installed-app-smoke.ts
@@ -4,7 +4,6 @@ import { once } from "node:events";
 import {
   chmodSync,
   closeSync,
-  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -18,7 +17,7 @@ import {
 } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 
@@ -55,7 +54,6 @@ interface SmokeDirs {
   homeDir: string;
   dataDir: string;
   daemonDir: string;
-  frontendDir: string;
   binDir: string;
   logDir: string;
   daemonLogPath: string;
@@ -209,7 +207,7 @@ function usage(): string {
   return [
     "Usage: bun run scripts/installed-app-smoke.ts [options]",
     "",
-    "Validates a packaged Little Imp release archive as an installed app in an isolated temp home.",
+    "Validates a packaged Grimoire release archive as an installed app in an isolated temp home.",
     "",
     "Options:",
     "  --source local|published",
@@ -246,7 +244,6 @@ function createSmokeDirs(): SmokeDirs {
   const homeDir = join(rootDir, "home");
   const dataDir = join(homeDir, ".local", "share", "littleimp");
   const daemonDir = join(dataDir, "daemon");
-  const frontendDir = join(dataDir, "dist");
   const binDir = join(homeDir, ".local", "bin");
   const logDir = join(dataDir, "logs");
   const unpackDir = join(rootDir, "unpacked");
@@ -262,7 +259,6 @@ function createSmokeDirs(): SmokeDirs {
     homeDir,
     dataDir,
     daemonDir,
-    frontendDir,
     binDir,
     logDir,
     daemonLogPath: join(logDir, "daemon.log"),
@@ -529,26 +525,43 @@ function defaultSignatureRunner(
   return spawnSync(command, args, options);
 }
 
-function installRuntimeFromRelease(releaseRoot: string, dirs: SmokeDirs, port: number): void {
-  logStep("Installing runtime from release archive into isolated temp home");
-  rmSync(dirs.daemonDir, { recursive: true, force: true });
-  rmSync(dirs.frontendDir, { recursive: true, force: true });
-  mkdirSync(dirname(dirs.daemonDir), { recursive: true });
-  mkdirSync(dirname(dirs.frontendDir), { recursive: true });
-  cpSync(join(releaseRoot, "daemon"), dirs.daemonDir, { recursive: true });
-  cpSync(join(releaseRoot, "dist"), dirs.frontendDir, { recursive: true });
+function writeExecutable(path: string, contents: string): void {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
 
-  const cliPath = join(dirs.binDir, "littleimp");
-  writeFileSync(
-    cliPath,
-    [
-      "#!/usr/bin/env bash",
-      "set -euo pipefail",
-      `exec bun ${JSON.stringify(join(dirs.daemonDir, "src", "cli.ts"))} "$@"`,
-      "",
-    ].join("\n")
+function createInstallerCommandShims(dirs: SmokeDirs, platform: ReleasePlatform): string {
+  const shimDir = join(dirs.rootDir, "installer-shims");
+  mkdirSync(shimDir, { recursive: true });
+
+  writeExecutable(
+    join(shimDir, "curl"),
+    ["#!/usr/bin/env bash", "printf '{\"status\":\"ok\"}\\n'", ""].join("\n")
   );
-  chmodSync(cliPath, 0o755);
+
+  if (platform === "macos") {
+    writeExecutable(join(shimDir, "launchctl"), ["#!/usr/bin/env bash", "exit 0", ""].join("\n"));
+  } else {
+    writeExecutable(
+      join(shimDir, "systemctl"),
+      [
+        "#!/usr/bin/env bash",
+        'if [[ "${1:-}" == "--user" && "${2:-}" == "is-active" ]]; then exit 1; fi',
+        "exit 0",
+        "",
+      ].join("\n")
+    );
+  }
+
+  return shimDir;
+}
+
+function installRuntimeFromRelease(releaseRoot: string, dirs: SmokeDirs, port: number): void {
+  logStep("Installing runtime from release archive with its native installer");
+  assert(existsSync(join(releaseRoot, "bin")), "Release archive is missing its CLI entrypoint directory");
+  for (const command of ["grimoire", "littleimp"]) {
+    assert(existsSync(join(releaseRoot, "bin", command)), `Release archive is missing its ${command} CLI entrypoint`);
+  }
 
   writeFileSync(
     join(dirs.dataDir, ".env"),
@@ -562,14 +575,17 @@ function installRuntimeFromRelease(releaseRoot: string, dirs: SmokeDirs, port: n
     ].join("\n")
   );
 
-  logStep("Installing daemon production dependencies");
-  const install = spawnSync("bun", ["install", "--production"], {
-    cwd: dirs.daemonDir,
-    env: smokeEnv(dirs, port),
+  const installEnv = smokeEnv(dirs, port);
+  const installer = spawnSync("bash", [join(releaseRoot, "daemon", "install.sh")], {
+    cwd: join(releaseRoot, "daemon"),
+    env: {
+      ...installEnv,
+      PATH: `${createInstallerCommandShims(dirs, detectReleasePlatform())}:${installEnv.PATH ?? ""}`,
+    },
     stdio: "inherit",
   });
-  if (install.status !== 0) {
-    throw new Error(`bun install --production failed with exit code ${install.status ?? "unknown"}`);
+  if (installer.status !== 0) {
+    throw new Error(`Release archive installer failed with exit code ${installer.status ?? "unknown"}`);
   }
 }
 
@@ -811,10 +827,29 @@ export async function runCommandCapture(
   });
 }
 
+async function runCliHelpChecks(dirs: SmokeDirs, port: number, version: string): Promise<void> {
+  logStep("grimoire CLI and littleimp compatibility alias");
+  for (const command of ["grimoire", "littleimp"]) {
+    const result = await runCommandCapture(command, ["--help"], {
+      cwd: dirs.daemonDir,
+      env: smokeEnv(dirs, port),
+    });
+
+    if (result.timedOut) {
+      throw new Error(`${command} --help timed out after ${COMMAND_TIMEOUT_MS}ms`);
+    }
+    if (result.status !== 0) {
+      throw new Error(`${command} --help failed:\n${result.stderr}`);
+    }
+    assert(result.stdout.includes(version), `${command} --help did not report ${version}`);
+    assert(result.stdout.includes("Usage:\n  grimoire "), `${command} --help did not use the grimoire command name`);
+  }
+}
+
 async function runCliUpdateCheck(dirs: SmokeDirs, port: number, updateSourceUrl: string): Promise<void> {
-  logStep("littleimp update check");
+  logStep("grimoire update check");
   const result = await runCommandCapture(
-    "littleimp",
+    "grimoire",
     ["update", "check", "--json", "--source", updateSourceUrl],
     {
       cwd: dirs.daemonDir,
@@ -826,10 +861,10 @@ async function runCliUpdateCheck(dirs: SmokeDirs, port: number, updateSourceUrl:
   );
 
   if (result.timedOut) {
-    throw new Error(`littleimp update check timed out after ${COMMAND_TIMEOUT_MS}ms`);
+    throw new Error(`grimoire update check timed out after ${COMMAND_TIMEOUT_MS}ms`);
   }
   if (result.status !== 0) {
-    throw new Error(`littleimp update check failed:\n${result.stderr}`);
+    throw new Error(`grimoire update check failed:\n${result.stderr}`);
   }
 
   const payload = JSON.parse(result.stdout) as { current_version?: string; latest?: { version?: string } | null };
@@ -871,6 +906,7 @@ async function runInstalledAppSmoke(options: {
 
     const releaseRoot = extractReleaseArchive(archivePath, dirs, platform);
     installRuntimeFromRelease(releaseRoot, dirs, port);
+    await runCliHelpChecks(dirs, port, version);
 
     daemon = startDaemon(dirs, port);
     await waitForHealth(baseUrl);
@@ -899,9 +935,22 @@ async function runInstalledAppSmoke(options: {
     logStep("uninstall without purge");
     await stopDaemon(daemon);
     daemon = null;
-    rmSync(dirs.daemonDir, { recursive: true, force: true });
-    rmSync(dirs.frontendDir, { recursive: true, force: true });
-    rmSync(join(dirs.binDir, "littleimp"), { force: true });
+    const uninstallEnv = smokeEnv(dirs, port);
+    const uninstall = spawnSync("bash", [join(dirs.daemonDir, "install.sh"), "--uninstall"], {
+      cwd: dirs.daemonDir,
+      env: {
+        ...uninstallEnv,
+        PATH: `${createInstallerCommandShims(dirs, detectReleasePlatform())}:${uninstallEnv.PATH ?? ""}`,
+      },
+      stdio: "inherit",
+    });
+    if (uninstall.status !== 0) {
+      throw new Error(`Native uninstall failed with exit code ${uninstall.status ?? "unknown"}`);
+    }
+    assert(!existsSync(dirs.daemonDir), "Uninstall without purge left daemon files behind");
+    for (const command of ["grimoire", "littleimp"]) {
+      assert(!existsSync(join(dirs.binDir, command)), `Uninstall without purge left ${command} behind`);
+    }
     assert(existsSync(join(dirs.dataDir, "littleimp.db")), "Uninstall without purge removed user data");
 
     success = true;

--- a/scripts/release-packager.test.ts
+++ b/scripts/release-packager.test.ts
@@ -60,10 +60,13 @@ describe("release packager", () => {
     expect(readFileSync(join(result.payloadRoot, "daemon/src/db/migrations/0001_initial.sql"), "utf8")).toContain(
       "SELECT 1"
     );
+    expect(readFileSync(join(result.payloadRoot, "bin/grimoire"), "utf8")).toContain("../daemon/src/cli.ts");
     expect(readFileSync(join(result.payloadRoot, "bin/littleimp"), "utf8")).toContain("../daemon/src/cli.ts");
     expect(readFileSync(join(result.payloadRoot, "RELEASE.json"), "utf8")).toContain("\"platform\": \"linux\"");
+    expect(readFileSync(join(result.payloadRoot, "RELEASE.json"), "utf8")).toContain("\"cli\": \"bin/grimoire\"");
     expect(readFileSync(join(result.payloadRoot, "SIGNING.md"), "utf8")).toContain("detach-sign");
 
+    expect(statSync(join(result.payloadRoot, "bin/grimoire")).mode & 0o111).toBeGreaterThan(0);
     expect(statSync(join(result.payloadRoot, "bin/littleimp")).mode & 0o111).toBeGreaterThan(0);
     expect(statSync(join(result.payloadRoot, "daemon/install.sh")).mode & 0o111).toBeGreaterThan(0);
 

--- a/scripts/release-packager.ts
+++ b/scripts/release-packager.ts
@@ -265,19 +265,20 @@ function copyDaemonRuntime(projectRoot: string, payloadRoot: string): void {
 
 function writeCliEntrypoint(payloadRoot: string): void {
   const binDir = join(payloadRoot, "bin");
-  const cliPath = join(binDir, "littleimp");
   mkdirSync(binDir, { recursive: true });
-  writeFileSync(
-    cliPath,
-    [
-      "#!/usr/bin/env bash",
-      "set -euo pipefail",
-      'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
-      'exec bun "${SCRIPT_DIR}/../daemon/src/cli.ts" "$@"',
-      "",
-    ].join("\n")
-  );
-  chmodSync(cliPath, 0o755);
+  const cliContents = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+    'exec bun "${SCRIPT_DIR}/../daemon/src/cli.ts" "$@"',
+    "",
+  ].join("\n");
+
+  for (const name of ["grimoire", "littleimp"]) {
+    const cliPath = join(binDir, name);
+    writeFileSync(cliPath, cliContents);
+    chmodSync(cliPath, 0o755);
+  }
 }
 
 function writeVersionMetadata(options: {
@@ -302,7 +303,7 @@ function writeVersionMetadata(options: {
           installer: "daemon/install.sh",
           daemon: "daemon",
           frontend: "dist",
-          cli: "bin/littleimp",
+          cli: "bin/grimoire",
           checksums: CHECKSUMS_FILE,
         },
       },

--- a/src/components/DaemonOfflineBanner.tsx
+++ b/src/components/DaemonOfflineBanner.tsx
@@ -11,8 +11,7 @@ export function DaemonOfflineBanner({ online, loading }: DaemonOfflineBannerProp
     <div className="flex items-center gap-2 bg-destructive/10 border border-destructive/30 text-destructive text-xs px-4 py-2 rounded-md mx-4 mt-3">
       <WifiOff className="h-3.5 w-3.5 shrink-0" />
       <span>
-        Daemon offline — changes won't be saved.{" "}
-        <span className="font-mono">little-imp daemon start</span> to reconnect.
+        Daemon offline — changes won't be saved. Start the Grimoire daemon with your platform service manager to reconnect.
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary

- Add a Homebrew formula using checksummed release archives, core Bun, frozen dependency installation, executable grimoire and littleimp CLI wrappers, and a managed littleimpd service.
- Make grimoire the primary CLI name while preserving littleimp as a compatibility alias and keeping existing daemon, service, and data identifiers stable.
- Route Homebrew-managed updates through brew upgrade grimoire instead of the native self-updater.
- Exercise the native installer, upgrade/data-preservation path, CLI aliases, service isolation, and uninstall path in the installed-app smoke test.
- Update installation, migration, diagnostics, FAQ, security, and UI guidance.

## Validation

- npm run check
- npm run test:e2e:installed
- Focused packaging tests: 17/17
- brew style Formula/grimoire.rb
- Shell and Ruby syntax checks
- git diff --check

## Release note

The formula is prepared for the goniszewski/grimoire tap. Live Homebrew validation still requires publishing a repackaged release archive containing the new CLI entrypoint and update guard, followed by the published-archive and tap smoke tests. This PR does not publish the release or tap.
