### PR TITLE
feat: add browser companion protocol

### DIFF
--- a/API.md
+++ b/API.md
@@ -2401,6 +2401,8 @@ Request body:
 | `category_id` | string \| null | no | Existing category ID to assign |
 | `category` | string | no | Root category name to resolve or create when category_id is omitted |
 | `notes` | string \| null | no | Personal notes, or null to leave empty |
+| `is_pinned` | boolean | no | Whether the new bookmark should be pinned |
+| `read_later` | boolean | no | Whether the new bookmark should be added to Read Later |
 | `source` | CaptureSource | no |  |
 | `source.client` | string \| null | no | Optional local integration client label |
 | `source.source_url` | string \| null | no | Optional public HTTP or HTTPS page/context URL |
@@ -3175,6 +3177,8 @@ Protected one-click capture request for explicit local integrations
 | `category_id` | string \| null | no | Existing category ID to assign |
 | `category` | string | no | Root category name to resolve or create when category_id is omitted |
 | `notes` | string \| null | no | Personal notes, or null to leave empty |
+| `is_pinned` | boolean | no | Whether the new bookmark should be pinned |
+| `read_later` | boolean | no | Whether the new bookmark should be added to Read Later |
 | `source` | CaptureSource | no |  |
 | `source.client` | string \| null | no | Optional local integration client label |
 | `source.source_url` | string \| null | no | Optional public HTTP or HTTPS page/context URL |
@@ -4567,6 +4571,9 @@ Authenticated capabilities advertised to packaged browser extensions
 | `endpoints` | object | yes |  |
 | `endpoints.capture` | string | yes | Authenticated bookmark capture path |
 | `endpoints.taxonomy` | string | yes | Authenticated category and tag discovery path |
+| `capture_fields` | object | no | Optional capture fields supported by this daemon |
+| `capture_fields.is_pinned` | boolean | yes | Capture accepts an initial pinned state |
+| `capture_fields.read_later` | boolean | yes | Capture accepts an initial Read Later state |
 | `limits` | object | yes |  |
 | `limits.request_bytes` | integer | yes | Maximum capture request bytes |
 | `limits.title_characters` | integer | yes | Maximum title characters |
@@ -4587,6 +4594,9 @@ Browser integration capability response
 | `data.endpoints` | object | yes |  |
 | `data.endpoints.capture` | string | yes | Authenticated bookmark capture path |
 | `data.endpoints.taxonomy` | string | yes | Authenticated category and tag discovery path |
+| `data.capture_fields` | object | no | Optional capture fields supported by this daemon |
+| `data.capture_fields.is_pinned` | boolean | yes | Capture accepts an initial pinned state |
+| `data.capture_fields.read_later` | boolean | yes | Capture accepts an initial Read Later state |
 | `data.limits` | object | yes |  |
 | `data.limits.request_bytes` | integer | yes | Maximum capture request bytes |
 | `data.limits.title_characters` | integer | yes | Maximum title characters |

--- a/API.md
+++ b/API.md
@@ -2481,6 +2481,43 @@ Content-Type: application/json
 }
 ```
 
+#### GET /integrations/browser/v1/capabilities
+
+Negotiate the packaged browser extension capture protocol.
+
+Requires a managed integration bearer token. Packaged Chrome and Firefox clients use this endpoint to distinguish current Grimoire from the legacy account API before sending capture data. The response describes stable paths and enforced field limits; clients must not infer compatibility from the daemon marketing version alone.
+
+Responses:
+
+| Status | Content type | Schema | Description |
+|---|---|---|---|
+| `200` | application/json | `BrowserIntegrationCapabilitiesResponse` | Supported browser integration capabilities |
+| `401` | application/problem+json | `ProblemDetails` | Missing, invalid, rotated, or revoked integration token |
+
+Examples:
+
+**Negotiate browser capture support**
+
+Request:
+
+```bash
+curl http://127.0.0.1:3210/integrations/browser/v1/capabilities \
+  -H "Authorization: Bearer limp_it_example"
+```
+
+#### GET /integrations/browser/v1/taxonomy
+
+List the categories and tags available to the packaged browser extension.
+
+Requires a managed integration bearer token. This route keeps extension-origin reads inside the versioned browser integration surface instead of exposing unrelated local-library GET routes.
+
+Responses:
+
+| Status | Content type | Schema | Description |
+|---|---|---|---|
+| `200` | application/json | `BrowserIntegrationTaxonomyResponse` | Browser capture categories and tags |
+| `401` | application/problem+json | `ProblemDetails` | Missing, invalid, rotated, or revoked integration token |
+
 #### GET /capture/bookmarklet
 
 Bookmarklet capture bridge page.
@@ -4517,6 +4554,64 @@ Response data
 | `version` | string | yes | Daemon package version |
 | `uptime` | integer | yes | Process uptime in milliseconds |
 | `queueSize` | integer | yes | Queued background jobs |
+
+### BrowserIntegrationCapabilities
+
+Authenticated capabilities advertised to packaged browser extensions
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `protocol` | "grimoire-browser-capture" | yes | Stable browser integration protocol identifier |
+| `protocol_version` | integer | yes | Browser integration protocol version |
+| `grimoire_version` | string | yes | Daemon package version |
+| `endpoints` | object | yes |  |
+| `endpoints.capture` | string | yes | Authenticated bookmark capture path |
+| `endpoints.taxonomy` | string | yes | Authenticated category and tag discovery path |
+| `limits` | object | yes |  |
+| `limits.request_bytes` | integer | yes | Maximum capture request bytes |
+| `limits.title_characters` | integer | yes | Maximum title characters |
+| `limits.notes_characters` | integer | yes | Maximum notes characters |
+| `limits.selected_text_characters` | integer | yes | Maximum selected text characters |
+| `limits.tag_characters` | integer | yes | Maximum characters per tag |
+
+### BrowserIntegrationCapabilitiesResponse
+
+Browser integration capability response
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `data` | BrowserIntegrationCapabilities | yes |  |
+| `data.protocol` | "grimoire-browser-capture" | yes | Stable browser integration protocol identifier |
+| `data.protocol_version` | integer | yes | Browser integration protocol version |
+| `data.grimoire_version` | string | yes | Daemon package version |
+| `data.endpoints` | object | yes |  |
+| `data.endpoints.capture` | string | yes | Authenticated bookmark capture path |
+| `data.endpoints.taxonomy` | string | yes | Authenticated category and tag discovery path |
+| `data.limits` | object | yes |  |
+| `data.limits.request_bytes` | integer | yes | Maximum capture request bytes |
+| `data.limits.title_characters` | integer | yes | Maximum title characters |
+| `data.limits.notes_characters` | integer | yes | Maximum notes characters |
+| `data.limits.selected_text_characters` | integer | yes | Maximum selected text characters |
+| `data.limits.tag_characters` | integer | yes | Maximum characters per tag |
+
+### BrowserIntegrationTaxonomy
+
+Authenticated taxonomy subset used by the browser extension
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `categories` | array<CategoryNode> | yes | Category tree |
+| `tags` | array<TagWithCount> | yes | Tags |
+
+### BrowserIntegrationTaxonomyResponse
+
+Browser integration taxonomy response
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `data` | BrowserIntegrationTaxonomy | yes |  |
+| `data.categories` | array<CategoryNode> | yes | Category tree |
+| `data.tags` | array<TagWithCount> | yes | Tags |
 
 ### Diagnostics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Grimoire will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.2.0] - 2026-09-07
+
+### Added
+- Versioned Companion protocol discovery and capability negotiation for official
+  browser extensions.
+- Authenticated single-page and bulk-tab capture with editable titles, notes,
+  categories, tags, selected text, pinning, and Read Later state.
+- Managed integration tokens for Companion, bookmarklets, MCP clients, and
+  other supported local integrations.
+
+### Changed
+- Browser Integration settings now explain how named integration tokens are
+  shared across supported clients and recommend separate tokens for independent
+  revocation.
+
+### Fixed
+- Opening Browser Integration settings from an extension now loads the SPA
+  instead of returning the JSON settings endpoint.
+
 ## [1.1.0] - 2026-08-12
 
 ### Added

--- a/Formula/grimoire.rb
+++ b/Formula/grimoire.rb
@@ -6,11 +6,11 @@ class Grimoire < Formula
   depends_on "oven-sh/bun/bun"
 
   if OS.mac?
-    url "https://github.com/goniszewski/grimoire/releases/download/v1.1.0/little-imp-1.1.0-macos.tar.gz"
-    sha256 "c68bc963602a79631c76df223b9cc4a3709a0d382c0b117288f27c72da96c88f"
+    url "https://github.com/goniszewski/grimoire/releases/download/v1.2.0/little-imp-1.2.0-macos.tar.gz"
+    sha256 "3f67b1d94ca59170eedcfc398923afd1c8b9e2f9770b77f72ceccfe3e16b459f"
   elsif OS.linux?
-    url "https://github.com/goniszewski/grimoire/releases/download/v1.1.0/little-imp-1.1.0-linux.tar.gz"
-    sha256 "50429c64e2befeca1daca6d44a95d74f755f7be4a16ed869d68a80007809d340"
+    url "https://github.com/goniszewski/grimoire/releases/download/v1.2.0/little-imp-1.2.0-linux.tar.gz"
+    sha256 "00bbbbba2baab973db4084c72d2c7f78f5b93b6b8adf63176c62a9066905c698"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <br>
 
 [![Quality Gates](https://github.com/goniszewski/grimoire/actions/workflows/quality.yml/badge.svg?branch=main)](https://github.com/goniszewski/grimoire/actions/workflows/quality.yml)
-![Release target](https://img.shields.io/badge/release-1.1.0-7c3aed)
+![Release target](https://img.shields.io/badge/release-1.2.0-7c3aed)
 ![Bun 1.x](https://img.shields.io/badge/Bun-1.x-black)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littleimpd",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/daemon/src/api/contract.ts
+++ b/daemon/src/api/contract.ts
@@ -1456,6 +1456,59 @@ const schemas = {
     },
     ["status", "version", "uptime", "queueSize"]
   ),
+  BrowserIntegrationCapabilities: objectSchema(
+    {
+      protocol: stringSchema("Stable browser integration protocol identifier", {
+        enum: ["grimoire-browser-capture"],
+      }),
+      protocol_version: integerSchema("Browser integration protocol version", {
+        minimum: 1,
+        maximum: 1,
+      }),
+      grimoire_version: stringSchema("Daemon package version"),
+      endpoints: objectSchema(
+        {
+          capture: stringSchema("Authenticated bookmark capture path"),
+          taxonomy: stringSchema("Authenticated category and tag discovery path"),
+        },
+        ["capture", "taxonomy"]
+      ),
+      limits: objectSchema(
+        {
+          request_bytes: integerSchema("Maximum capture request bytes", { minimum: 1 }),
+          title_characters: integerSchema("Maximum title characters", { minimum: 1 }),
+          notes_characters: integerSchema("Maximum notes characters", { minimum: 1 }),
+          selected_text_characters: integerSchema("Maximum selected text characters", { minimum: 1 }),
+          tag_characters: integerSchema("Maximum characters per tag", { minimum: 1 }),
+        },
+        [
+          "request_bytes",
+          "title_characters",
+          "notes_characters",
+          "selected_text_characters",
+          "tag_characters",
+        ]
+      ),
+    },
+    ["protocol", "protocol_version", "grimoire_version", "endpoints", "limits"],
+    "Authenticated capabilities advertised to packaged browser extensions"
+  ),
+  BrowserIntegrationCapabilitiesResponse: envelope(
+    ref("BrowserIntegrationCapabilities"),
+    "Browser integration capability response"
+  ),
+  BrowserIntegrationTaxonomy: objectSchema(
+    {
+      categories: arrayOf(ref("CategoryNode"), "Category tree"),
+      tags: arrayOf(ref("TagWithCount"), "Tags"),
+    },
+    ["categories", "tags"],
+    "Authenticated taxonomy subset used by the browser extension"
+  ),
+  BrowserIntegrationTaxonomyResponse: envelope(
+    ref("BrowserIntegrationTaxonomy"),
+    "Browser integration taxonomy response"
+  ),
   Diagnostics: objectSchema(
     {
       generated_at: stringSchema("Diagnostics generation timestamp", { format: "date-time" }),
@@ -3232,6 +3285,43 @@ export const apiContract = {
           },
         },
       ],
+    },
+    {
+      method: "GET",
+      path: "/integrations/browser/v1/capabilities",
+      tag: "Integrations",
+      summary: "Negotiate the packaged browser extension capture protocol.",
+      description:
+        "Requires a managed integration bearer token. Packaged Chrome and Firefox clients use this endpoint to distinguish current Grimoire from the legacy account API before sending capture data. The response describes stable paths and enforced field limits; clients must not infer compatibility from the daemon marketing version alone.",
+      responses: {
+        "200": jsonResponse(
+          "Supported browser integration capabilities",
+          ref("BrowserIntegrationCapabilitiesResponse")
+        ),
+        "401": problemResponse("Missing, invalid, rotated, or revoked integration token"),
+      },
+      examples: [
+        {
+          title: "Negotiate browser capture support",
+          request:
+            "curl http://127.0.0.1:3210/integrations/browser/v1/capabilities \\\n  -H \"Authorization: Bearer limp_it_example\"",
+        },
+      ],
+    },
+    {
+      method: "GET",
+      path: "/integrations/browser/v1/taxonomy",
+      tag: "Integrations",
+      summary: "List the categories and tags available to the packaged browser extension.",
+      description:
+        "Requires a managed integration bearer token. This route keeps extension-origin reads inside the versioned browser integration surface instead of exposing unrelated local-library GET routes.",
+      responses: {
+        "200": jsonResponse(
+          "Browser capture categories and tags",
+          ref("BrowserIntegrationTaxonomyResponse")
+        ),
+        "401": problemResponse("Missing, invalid, rotated, or revoked integration token"),
+      },
     },
     {
       method: "GET",

--- a/daemon/src/api/contract.ts
+++ b/daemon/src/api/contract.ts
@@ -385,6 +385,8 @@ const schemas = {
       category_id: nullable(stringSchema("Existing category ID to assign")),
       category: stringSchema("Root category name to resolve or create when category_id is omitted", { maxLength: 100 }),
       notes: nullable(stringSchema("Personal notes, or null to leave empty", { maxLength: 100000 })),
+      is_pinned: booleanSchema("Whether the new bookmark should be pinned"),
+      read_later: booleanSchema("Whether the new bookmark should be added to Read Later"),
       source: ref("CaptureSource"),
     },
     ["url"],
@@ -1472,6 +1474,14 @@ const schemas = {
           taxonomy: stringSchema("Authenticated category and tag discovery path"),
         },
         ["capture", "taxonomy"]
+      ),
+      capture_fields: objectSchema(
+        {
+          is_pinned: booleanSchema("Capture accepts an initial pinned state"),
+          read_later: booleanSchema("Capture accepts an initial Read Later state"),
+        },
+        ["is_pinned", "read_later"],
+        "Optional capture fields supported by this daemon"
       ),
       limits: objectSchema(
         {

--- a/daemon/src/routes/browser-integration.ts
+++ b/daemon/src/routes/browser-integration.ts
@@ -26,6 +26,10 @@ export function createBrowserIntegrationRoute(deps: BrowserIntegrationDeps): Hon
           capture: "/capture",
           taxonomy: "/integrations/browser/v1/taxonomy",
         },
+        capture_fields: {
+          is_pinned: true,
+          read_later: true,
+        },
         limits: {
           request_bytes: 256 * 1024,
           title_characters: 2_000,

--- a/daemon/src/routes/browser-integration.ts
+++ b/daemon/src/routes/browser-integration.ts
@@ -1,0 +1,50 @@
+import { Hono } from "hono";
+import type { Database } from "bun:sqlite";
+import { requireIntegrationToken } from "../lib/integration-auth.js";
+import { CategoryRepository } from "../db/category-repository.js";
+import { TagRepository } from "../db/tag-repository.js";
+
+interface BrowserIntegrationDeps {
+  db: Database;
+  version: string;
+}
+
+export function createBrowserIntegrationRoute(deps: BrowserIntegrationDeps): Hono {
+  const router = new Hono();
+  const categoryRepo = new CategoryRepository(deps.db);
+  const tagRepo = new TagRepository(deps.db);
+
+  router.use("/integrations/browser/v1/*", requireIntegrationToken(deps.db));
+
+  router.get("/integrations/browser/v1/capabilities", (c) => {
+    return c.json({
+      data: {
+        protocol: "grimoire-browser-capture",
+        protocol_version: 1,
+        grimoire_version: deps.version,
+        endpoints: {
+          capture: "/capture",
+          taxonomy: "/integrations/browser/v1/taxonomy",
+        },
+        limits: {
+          request_bytes: 256 * 1024,
+          title_characters: 2_000,
+          notes_characters: 100_000,
+          selected_text_characters: 10_000,
+          tag_characters: 50,
+        },
+      },
+    });
+  });
+
+  router.get("/integrations/browser/v1/taxonomy", (c) => {
+    return c.json({
+      data: {
+        categories: categoryRepo.listTree(),
+        tags: tagRepo.list(),
+      },
+    });
+  });
+
+  return router;
+}

--- a/daemon/src/routes/capture.ts
+++ b/daemon/src/routes/capture.ts
@@ -18,7 +18,17 @@ interface CaptureDeps {
 
 type ProblemStatus = 400 | 404 | 409 | 422 | 500;
 
-const captureFields = new Set(["url", "title", "tags", "category_id", "category", "notes", "source"]);
+const captureFields = new Set([
+  "url",
+  "title",
+  "tags",
+  "category_id",
+  "category",
+  "notes",
+  "is_pinned",
+  "read_later",
+  "source",
+]);
 const sourceFields = new Set(["client", "source_url", "referrer_url", "selected_text"]);
 const tagPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 const MAX_TITLE_LENGTH = 2000;
@@ -126,6 +136,14 @@ function parseTags(body: Record<string, unknown>): string[] | undefined {
   return tags;
 }
 
+function parseOptionalBoolean(body: Record<string, unknown>, field: string): boolean | undefined {
+  if (!(field in body)) return undefined;
+  if (typeof body[field] !== "boolean") {
+    throw new ValidationError(`\`${field}\` must be a boolean`);
+  }
+  return body[field];
+}
+
 function parseSource(body: Record<string, unknown>): CaptureMetadataInput {
   if (!("source" in body) || body.source === null || body.source === undefined) return {};
   if (!isRecord(body.source)) {
@@ -222,6 +240,8 @@ type DoCaptureInput = {
   resolveCategory?: () => string | null;
   tags?: string[];
   notes?: string | null;
+  isPinned?: boolean;
+  readLater?: boolean;
   source?: CaptureMetadataInput;
 };
 
@@ -271,10 +291,17 @@ function doCapture(
     if (!fetched) throw new Error("Captured bookmark could not be fetched");
 
     // Apply tags and notes after creation if provided
-    if (input.tags !== undefined || input.notes !== undefined) {
+    if (
+      input.tags !== undefined ||
+      input.notes !== undefined ||
+      input.isPinned !== undefined ||
+      input.readLater !== undefined
+    ) {
       const updated = bookmarkRepo.update(fetched.id, {
         ...(input.tags !== undefined ? { tags: input.tags } : {}),
         ...(input.notes !== undefined ? { notes: input.notes } : {}),
+        ...(input.isPinned !== undefined ? { is_pinned: input.isPinned ? 1 : 0 } : {}),
+        ...(input.readLater !== undefined ? { read_later: input.readLater ? 1 : 0 } : {}),
       });
       if (!updated) throw new Error("Captured bookmark could not be updated");
       fetched = updated;
@@ -453,6 +480,8 @@ export function createCaptureRoute(deps: CaptureDeps): Hono {
     let tags: string[] | undefined;
     let categorySelection: CategorySelection;
     let notes: string | null | undefined;
+    let isPinned: boolean | undefined;
+    let readLater: boolean | undefined;
     let source: CaptureMetadataInput;
     try {
       url = parsePublicUrl(body.url, "url");
@@ -461,6 +490,8 @@ export function createCaptureRoute(deps: CaptureDeps): Hono {
       categorySelection = parseCategorySelection(body);
       validateCategorySelection(categorySelection, categoryRepo);
       notes = parseOptionalText(body, "notes", MAX_NOTES_LENGTH, { emptyAsNull: true, nullable: true });
+      isPinned = parseOptionalBoolean(body, "is_pinned");
+      readLater = parseOptionalBoolean(body, "read_later");
       source = parseSource(body);
     } catch (err) {
       if (err instanceof ValidationError) {
@@ -475,6 +506,8 @@ export function createCaptureRoute(deps: CaptureDeps): Hono {
         title,
         tags,
         notes,
+        isPinned,
+        readLater,
         resolveCategory: () => resolveCategoryId(categorySelection, categoryRepo),
         source,
       },

--- a/daemon/src/routes/settings.ts
+++ b/daemon/src/routes/settings.ts
@@ -1,4 +1,4 @@
-import { Hono, Context } from "hono";
+import { Hono, Context, type Next } from "hono";
 import { settingsManager, redactSettings, validateSettingsPatch } from "../settings.js";
 import { log } from "../logger.js";
 import { resolveRuntimeSettings } from "../runtime-settings.js";
@@ -41,7 +41,11 @@ export function createSettingsRoute(): Hono {
    * GET /settings
    * Returns current settings. API keys are redacted (shown as "***" if set).
    */
-  app.get("/settings", (c) => {
+  app.get("/settings", async (c, next: Next) => {
+    if (c.req.header("Accept")?.includes("text/html")) {
+      await next();
+      return;
+    }
     const settings = settingsManager.read();
     return ok(c, {
       ...redactSettings(settings),

--- a/daemon/src/server.ts
+++ b/daemon/src/server.ts
@@ -28,6 +28,7 @@ import { createMediaRoute } from "./routes/media.js";
 import { createIntegrationTokensRoute } from "./routes/integration-tokens.js";
 import { createCaptureRoute } from "./routes/capture.js";
 import { createDemoRoute } from "./routes/demo.js";
+import { createBrowserIntegrationRoute } from "./routes/browser-integration.js";
 import { validatePresentedIntegrationToken } from "./lib/integration-auth.js";
 import { join } from "path";
 import { existsSync } from "fs";
@@ -108,6 +109,43 @@ function isAllowedLocalOrigin(origin: string | undefined): boolean {
   return !!normalized && allowedBrowserOrigins().has(normalized);
 }
 
+function isBrowserExtensionOrigin(origin: string | undefined): boolean {
+  if (!origin) return false;
+  try {
+    const parsed = new URL(origin);
+    if (parsed.protocol !== "chrome-extension:" && parsed.protocol !== "moz-extension:") return false;
+    if (!parsed.hostname || parsed.username || parsed.password || parsed.search || parsed.hash) return false;
+    return parsed.pathname === "" || parsed.pathname === "/";
+  } catch {
+    return false;
+  }
+}
+
+function hasBrowserExtensionScheme(origin: string | undefined): boolean {
+  if (!origin) return false;
+  try {
+    const protocol = new URL(origin).protocol;
+    return protocol === "chrome-extension:" || protocol === "moz-extension:";
+  } catch {
+    return false;
+  }
+}
+
+const BROWSER_EXTENSION_INTEGRATION_PATHS = new Set([
+  "/capture",
+  "/integrations/browser/v1/capabilities",
+  "/integrations/browser/v1/taxonomy",
+]);
+
+function isBrowserExtensionIntegrationPath(path: string): boolean {
+  return BROWSER_EXTENSION_INTEGRATION_PATHS.has(path);
+}
+
+function isAllowedRequestOrigin(origin: string | undefined, path: string): boolean {
+  return isAllowedLocalOrigin(origin) ||
+    (isBrowserExtensionIntegrationPath(path) && isBrowserExtensionOrigin(origin));
+}
+
 function isValidCspSourceOrigin(origin: string): boolean {
   try {
     const parsed = new URL(origin);
@@ -175,15 +213,33 @@ async function enforceLocalOrigin(c: Context, next: Next): Promise<Response | vo
   const origin = c.req.header("origin");
   const method = c.req.method;
   const isPreflight = method === "OPTIONS" && !!c.req.header("access-control-request-method");
-  if (isPreflight && origin && !isAllowedLocalOrigin(origin)) {
+  if (isPreflight && origin && !isAllowedRequestOrigin(origin, c.req.path)) {
+    return c.json({ error: "Origin is not allowed for this local daemon" }, 403);
+  }
+
+  if (hasBrowserExtensionScheme(origin) && !isAllowedRequestOrigin(origin, c.req.path)) {
     return c.json({ error: "Origin is not allowed for this local daemon" }, 403);
   }
 
   const unsafeBrowserRequest = !!origin && method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
-  if (unsafeBrowserRequest && !isAllowedLocalOrigin(origin)) {
+  if (unsafeBrowserRequest && !isAllowedRequestOrigin(origin, c.req.path)) {
     return c.json({ error: "Origin is not allowed for this local daemon" }, 403);
   }
   await next();
+}
+
+async function applyBrowserExtensionCors(c: Context, next: Next): Promise<void> {
+  const origin = c.req.header("origin");
+  if (!isBrowserExtensionOrigin(origin) || !isBrowserExtensionIntegrationPath(c.req.path)) {
+    await next();
+    return;
+  }
+
+  await next();
+  c.header("Access-Control-Allow-Origin", origin);
+  c.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  c.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  c.header("Vary", "Origin", { append: true });
 }
 
 async function enforceRequestBodyLimits(c: Context, next: Next): Promise<Response | void> {
@@ -227,6 +283,7 @@ export function createApp(deps: AppDeps): Hono {
 
   // Middleware
   app.use("*", applySecurityHeaders);
+  app.use("*", applyBrowserExtensionCors);
   app.use("*", enforceLocalOrigin);
   app.use("*", enforceRequestBodyLimits);
   app.use(
@@ -237,7 +294,18 @@ export function createApp(deps: AppDeps): Hono {
       allowHeaders: ["Content-Type", "Authorization", "X-LittleImp-Frontend"],
     })
   );
-  app.use("*", validatePresentedIntegrationToken(deps.db, new Set(["/mcp", "/capture"])));
+  app.use(
+    "*",
+    validatePresentedIntegrationToken(
+      deps.db,
+      new Set([
+        "/mcp",
+        "/capture",
+        "/integrations/browser/v1/capabilities",
+        "/integrations/browser/v1/taxonomy",
+      ])
+    )
+  );
 
   // JSON error handler — never leak internal details in production
   app.onError((err, c) => {
@@ -258,6 +326,7 @@ export function createApp(deps: AppDeps): Hono {
   app.route("/", createDiagnosticsRoute(deps));
   app.route("/", createBookmarksRoute({ db: deps.db, queue: deps.queue, dataDir: deps.dataDir ?? Config.DATA_DIR }));
   app.route("/", createCaptureRoute({ db: deps.db, queue: deps.queue }));
+  app.route("/", createBrowserIntegrationRoute({ db: deps.db, version: deps.version }));
   app.route("/", createMediaRoute({ db: deps.db, dataDir: deps.dataDir ?? Config.DATA_DIR }));
   app.route("/", createSearchRoute({ db: deps.db }));
   app.route("/", createImportRoute({ db: deps.db, queue: deps.queue }));

--- a/daemon/src/server.ts
+++ b/daemon/src/server.ts
@@ -109,11 +109,17 @@ function isAllowedLocalOrigin(origin: string | undefined): boolean {
   return !!normalized && allowedBrowserOrigins().has(normalized);
 }
 
+const BROWSER_EXTENSION_PROTOCOLS = new Set([
+  "chrome-extension:",
+  "moz-extension:",
+  "safari-web-extension:",
+]);
+
 function isBrowserExtensionOrigin(origin: string | undefined): boolean {
   if (!origin) return false;
   try {
     const parsed = new URL(origin);
-    if (parsed.protocol !== "chrome-extension:" && parsed.protocol !== "moz-extension:") return false;
+    if (!BROWSER_EXTENSION_PROTOCOLS.has(parsed.protocol)) return false;
     if (!parsed.hostname || parsed.username || parsed.password || parsed.search || parsed.hash) return false;
     return parsed.pathname === "" || parsed.pathname === "/";
   } catch {
@@ -124,8 +130,7 @@ function isBrowserExtensionOrigin(origin: string | undefined): boolean {
 function hasBrowserExtensionScheme(origin: string | undefined): boolean {
   if (!origin) return false;
   try {
-    const protocol = new URL(origin).protocol;
-    return protocol === "chrome-extension:" || protocol === "moz-extension:";
+    return BROWSER_EXTENSION_PROTOCOLS.has(new URL(origin).protocol);
   } catch {
     return false;
   }

--- a/daemon/src/test/cli-update.test.ts
+++ b/daemon/src/test/cli-update.test.ts
@@ -165,20 +165,20 @@ describe("littleimp update CLI", () => {
   it("reports the newest compatible release from the configured source", async () => {
     const harness = makeUpdateHarness([
       {
-        tag_name: "v1.2.0-beta.1",
-        name: "Grimoire 1.2.0 beta 1",
+        tag_name: "v1.3.0-beta.1",
+        name: "Grimoire 1.3.0 beta 1",
         draft: false,
         prerelease: true,
         published_at: "2026-05-18T12:00:00Z",
-        html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.2.0-beta.1",
+        html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.3.0-beta.1",
       },
       {
-        tag_name: "v1.2.0",
-        name: "Grimoire 1.2.0",
+        tag_name: "v1.3.0",
+        name: "Grimoire 1.3.0",
         draft: false,
         prerelease: false,
         published_at: "2026-05-17T12:00:00Z",
-        html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.2.0",
+        html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.3.0",
       },
     ]);
 
@@ -195,20 +195,20 @@ describe("littleimp update CLI", () => {
     expect(harness.calls[0].url).toBe("https://updates.example.test/releases");
     expect(harness.calls[0].init?.headers).toEqual({
       accept: "application/vnd.github+json",
-      "user-agent": "littleimp-update-check/1.1.0",
+      "user-agent": "littleimp-update-check/1.2.0",
     });
     expect(JSON.parse(harness.stdout[0])).toEqual({
-      current_version: "1.1.0",
+      current_version: "1.2.0",
       update_available: true,
       source: "https://updates.example.test/releases",
       channel: "stable",
       latest: {
-        version: "1.2.0",
-        tag: "v1.2.0",
-        name: "Grimoire 1.2.0",
+        version: "1.3.0",
+        tag: "v1.3.0",
+        name: "Grimoire 1.3.0",
         prerelease: false,
         published_at: "2026-05-17T12:00:00Z",
-        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.2.0",
+        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.3.0",
       },
     });
   });
@@ -295,7 +295,7 @@ describe("littleimp update CLI", () => {
 
     expect(code).toBe(0);
     expect(harness.stdout.join("\n")).toContain("Grimoire is up to date");
-    expect(harness.stdout.join("\n")).toContain("1.1.0");
+    expect(harness.stdout.join("\n")).toContain("1.2.0");
   });
 
   it("uses LITTLEIMP_UPDATE_SOURCE when no source flag is provided", async () => {
@@ -345,7 +345,7 @@ describe("littleimp update CLI", () => {
     expect(harness.spawnCalls[0].args).toContain("--upgrade");
     expect(harness.fetchCalls[0].url).toBe("http://127.0.0.1:3210/health");
     expect(JSON.parse(harness.stdout[0])).toMatchObject({
-      current_version: "1.1.0",
+      current_version: "1.2.0",
       upgraded_version: fixture.version,
       archive: fixture.archivePath,
       checksum_verified: true,
@@ -544,7 +544,7 @@ describe("littleimp update CLI", () => {
   });
 
   it("checks the release source before downloading the latest compatible upgrade when no version is provided", async () => {
-    const fixture = createUpgradeArchiveFixture({ version: "1.2.0", signature: true });
+    const fixture = createUpgradeArchiveFixture({ version: "1.3.0", signature: true });
     const stdout: string[] = [];
     const stderr: string[] = [];
     const fetchCalls: FetchCall[] = [];

--- a/daemon/src/test/integration/browser-integration.test.ts
+++ b/daemon/src/test/integration/browser-integration.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { createApp } from "../../server.js";
+import { JobQueue } from "../../queue.js";
+import { makeTestDb } from "../helpers/db.js";
+
+describe("browser extension integration", () => {
+  let db: Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    app = createApp({
+      db,
+      queue: new JobQueue(db),
+      startTime: new Date(),
+      version: "1.2.3-test",
+      staticDir: false,
+    });
+  });
+
+  afterEach(() => db.close());
+
+  async function token(): Promise<string> {
+    const response = await app.request("/integration-tokens", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: "http://127.0.0.1:3210" },
+      body: JSON.stringify({ name: "Grimoire Companion" }),
+    });
+    const body = (await response.json()) as { data: { token: string } };
+    return body.data.token;
+  }
+
+  it("advertises the versioned capture contract only to an authenticated client", async () => {
+    const unauthorized = await app.request("/integrations/browser/v1/capabilities");
+    expect(unauthorized.status).toBe(401);
+
+    const response = await app.request("/integrations/browser/v1/capabilities", {
+      headers: {
+        Authorization: `Bearer ${await token()}`,
+        Origin: "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "chrome-extension://abcdefghijklmnopabcdefghijklmnop"
+    );
+    expect(await response.json()).toMatchObject({
+      data: {
+        protocol: "grimoire-browser-capture",
+        protocol_version: 1,
+        grimoire_version: "1.2.3-test",
+        endpoints: {
+          capture: "/capture",
+          taxonomy: "/integrations/browser/v1/taxonomy",
+        },
+      },
+    });
+  });
+
+  it("accepts authenticated capture from Chrome and Firefox extension origins", async () => {
+    const bearer = await token();
+    for (const origin of [
+      "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
+      "moz-extension://8f2d3a0b-31dc-47f4-b783-36f8c9746ee8",
+    ]) {
+      const response = await app.request("/capture", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${bearer}`,
+          "Content-Type": "application/json",
+          Origin: origin,
+        },
+        body: JSON.stringify({ url: `https://example.com/${encodeURIComponent(origin)}` }),
+      });
+      expect(response.status).toBe(201);
+      expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    }
+  });
+
+  it("does not extend extension-origin access to other browser writes", async () => {
+    const response = await app.request("/tags", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${await token()}`,
+        "Content-Type": "application/json",
+        Origin: "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
+      },
+      body: JSON.stringify({ name: "blocked" }),
+    });
+    expect(response.status).toBe(403);
+  });
+
+  it("keeps extension-origin taxonomy reads authenticated and blocks unrelated reads", async () => {
+    const origin = "chrome-extension://abcdefghijklmnopabcdefghijklmnop";
+    const blocked = await app.request("/bookmarks", { headers: { Origin: origin } });
+    expect(blocked.status).toBe(403);
+    const unknownIntegrationRead = await app.request("/integrations/browser/v1/future", {
+      headers: { Origin: origin },
+    });
+    expect(unknownIntegrationRead.status).toBe(403);
+
+    const unauthorized = await app.request("/integrations/browser/v1/taxonomy", {
+      headers: { Origin: origin },
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const response = await app.request("/integrations/browser/v1/taxonomy", {
+      headers: { Origin: origin, Authorization: `Bearer ${await token()}` },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    expect(await response.json()).toEqual({ data: { categories: [], tags: [] } });
+  });
+
+  it("allows capture preflight without treating extension origins as first-party", async () => {
+    const response = await app.request("/capture", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "authorization,content-type",
+      },
+    });
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "chrome-extension://abcdefghijklmnopabcdefghijklmnop"
+    );
+  });
+});

--- a/daemon/src/test/integration/browser-integration.test.ts
+++ b/daemon/src/test/integration/browser-integration.test.ts
@@ -55,6 +55,10 @@ describe("browser extension integration", () => {
           capture: "/capture",
           taxonomy: "/integrations/browser/v1/taxonomy",
         },
+        capture_fields: {
+          is_pinned: true,
+          read_later: true,
+        },
       },
     });
   });

--- a/daemon/src/test/integration/browser-integration.test.ts
+++ b/daemon/src/test/integration/browser-integration.test.ts
@@ -63,11 +63,12 @@ describe("browser extension integration", () => {
     });
   });
 
-  it("accepts authenticated capture from Chrome and Firefox extension origins", async () => {
+  it("accepts authenticated capture from Chrome, Firefox, and Safari extension origins", async () => {
     const bearer = await token();
     for (const origin of [
       "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
       "moz-extension://8f2d3a0b-31dc-47f4-b783-36f8c9746ee8",
+      "safari-web-extension://com.goniszewski.Grimoire-Companion",
     ]) {
       const response = await app.request("/capture", {
         method: "POST",
@@ -84,16 +85,22 @@ describe("browser extension integration", () => {
   });
 
   it("does not extend extension-origin access to other browser writes", async () => {
-    const response = await app.request("/tags", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${await token()}`,
-        "Content-Type": "application/json",
-        Origin: "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
-      },
-      body: JSON.stringify({ name: "blocked" }),
-    });
-    expect(response.status).toBe(403);
+    const bearer = await token();
+    for (const origin of [
+      "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
+      "safari-web-extension://com.goniszewski.Grimoire-Companion",
+    ]) {
+      const response = await app.request("/tags", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${bearer}`,
+          "Content-Type": "application/json",
+          Origin: origin,
+        },
+        body: JSON.stringify({ name: "blocked" }),
+      });
+      expect(response.status).toBe(403);
+    }
   });
 
   it("keeps extension-origin taxonomy reads authenticated and blocks unrelated reads", async () => {
@@ -119,17 +126,20 @@ describe("browser extension integration", () => {
   });
 
   it("allows capture preflight without treating extension origins as first-party", async () => {
-    const response = await app.request("/capture", {
-      method: "OPTIONS",
-      headers: {
-        Origin: "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
-        "Access-Control-Request-Method": "POST",
-        "Access-Control-Request-Headers": "authorization,content-type",
-      },
-    });
-    expect(response.status).toBe(204);
-    expect(response.headers.get("access-control-allow-origin")).toBe(
-      "chrome-extension://abcdefghijklmnopabcdefghijklmnop"
-    );
+    for (const origin of [
+      "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
+      "safari-web-extension://com.goniszewski.Grimoire-Companion",
+    ]) {
+      const response = await app.request("/capture", {
+        method: "OPTIONS",
+        headers: {
+          Origin: origin,
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "authorization,content-type",
+        },
+      });
+      expect(response.status).toBe(204);
+      expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    }
   });
 });

--- a/daemon/src/test/integration/capture.test.ts
+++ b/daemon/src/test/integration/capture.test.ts
@@ -18,6 +18,8 @@ type CaptureResponse = {
       title: string | null;
       category_id: string | null;
       notes: string | null;
+      is_pinned: 0 | 1;
+      read_later: 0 | 1;
       tags: string[];
     };
     capture: {
@@ -96,6 +98,8 @@ describe("capture endpoint", () => {
         tags: ["TypeScript", "rag", "typescript"],
         category_id: category.id,
         notes: "Read after the SQLite notes.",
+        is_pinned: true,
+        read_later: true,
         source: {
           client: "bookmarklet",
           source_url: "https://example.com/article-list",
@@ -114,6 +118,8 @@ describe("capture endpoint", () => {
       title: "Captured resource",
       category_id: category.id,
       notes: "Read after the SQLite notes.",
+      is_pinned: 1,
+      read_later: 1,
       tags: ["rag", "typescript"],
     });
     expect(json.data.capture).toMatchObject({
@@ -132,6 +138,23 @@ describe("capture endpoint", () => {
       bookmarkId: json.data.bookmark.id,
       url: "https://example.com/capture",
     });
+  });
+
+  it("rejects non-boolean capture state fields", async () => {
+    const res = await app.request("/capture", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...bearer(await createToken()),
+      },
+      body: JSON.stringify({
+        url: "https://example.com/invalid-capture-state",
+        is_pinned: 1,
+      }),
+    });
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toMatchObject({ detail: "`is_pinned` must be a boolean" });
   });
 
   it("resolves a root category name when category_id is not supplied", async () => {

--- a/daemon/src/test/integration/static-frontend.test.ts
+++ b/daemon/src/test/integration/static-frontend.test.ts
@@ -63,4 +63,19 @@ describe("Static frontend serving", () => {
     expect(res.status).toBe(200);
     await expect(res.text()).resolves.toContain("<title>Little Imp</title>");
   });
+
+  it("serves the frontend for a browser navigation to the settings API path", async () => {
+    const res = await app.request("/settings", {
+      headers: { Accept: "text/html" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    await expect(res.text()).resolves.toContain("<title>Little Imp</title>");
+
+    const apiRes = await app.request("/settings");
+    expect(apiRes.status).toBe(200);
+    expect(apiRes.headers.get("content-type")).toContain("application/json");
+    expect((await apiRes.json())?.data).toBeDefined();
+  });
 });

--- a/daemon/src/test/integration/updates.test.ts
+++ b/daemon/src/test/integration/updates.test.ts
@@ -40,20 +40,20 @@ describe("Updates API", () => {
       calls.push({ url: String(url), init });
       return releasesResponse([
         {
-          tag_name: "v1.2.0-beta.1",
-          name: "Grimoire 1.2.0 beta 1",
+          tag_name: "v1.3.0-beta.1",
+          name: "Grimoire 1.3.0 beta 1",
           draft: false,
           prerelease: true,
           published_at: "2026-05-19T10:00:00Z",
-          html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.2.0-beta.1",
+          html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.3.0-beta.1",
         },
         {
-          tag_name: "v1.2.0",
-          name: "Grimoire 1.2.0",
+          tag_name: "v1.3.0",
+          name: "Grimoire 1.3.0",
           draft: false,
           prerelease: false,
           published_at: "2026-05-18T10:00:00Z",
-          html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.2.0",
+          html_url: "https://github.com/goniszewski/grimoire/releases/tag/v1.3.0",
         },
       ]);
     }) as typeof fetch;
@@ -65,7 +65,7 @@ describe("Updates API", () => {
     expect(calls[0].url).toBe(DEFAULT_UPDATE_SOURCE);
     expect(calls[0].init?.headers).toEqual({
       accept: "application/vnd.github+json",
-      "user-agent": "littleimp-update-check/1.1.0",
+      "user-agent": "littleimp-update-check/1.2.0",
     });
     const json = await res.json() as {
       data: {
@@ -84,17 +84,17 @@ describe("Updates API", () => {
       };
     };
     expect(json.data).toEqual({
-      current_version: "1.1.0",
+      current_version: "1.2.0",
       update_available: true,
       source: DEFAULT_UPDATE_SOURCE,
       channel: "stable",
       latest: {
-        version: "1.2.0",
-        tag: "v1.2.0",
-        name: "Grimoire 1.2.0",
+        version: "1.3.0",
+        tag: "v1.3.0",
+        name: "Grimoire 1.3.0",
         prerelease: false,
         published_at: "2026-05-18T10:00:00Z",
-        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.2.0",
+        url: "https://github.com/goniszewski/grimoire/releases/tag/v1.3.0",
       },
     });
   });

--- a/docs/03-using-grimoire.md
+++ b/docs/03-using-grimoire.md
@@ -43,7 +43,8 @@ Related bookmarks use embeddings when available.
 
 ## Capture from the browser
 
-There is no Chrome/Firefox store extension in 1.x yet. Use the built-in bookmarklet:
+The rewritten Chrome/Firefox extension is still being prepared for publication.
+Until it is available in the existing store listings, use the built-in bookmarklet:
 
 1. Open **Settings → Browser Integration**
 2. Create an integration token (the full secret is shown once — copy it if you need it elsewhere)
@@ -72,6 +73,9 @@ From Settings or the `littleimp` CLI you can create, list, verify, and restore l
 - **REST** — see [API.md](../API.md); health at `GET /health`
 - **MCP** — Streamable HTTP at `http://127.0.0.1:3210/mcp` with an integration bearer token
 - **Capture API** — token-protected `POST /capture` for same-machine clients
+- **Browser Companion protocol** — authenticated capability negotiation at
+  `GET /integrations/browser/v1/capabilities`, with authenticated taxonomy at
+  `GET /integrations/browser/v1/taxonomy`, before extension capture
 
 ## Privacy defaults
 

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -4911,6 +4911,144 @@
       ],
       "additionalProperties": false
     },
+    "BrowserIntegrationCapabilities": {
+      "type": "object",
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "description": "Stable browser integration protocol identifier",
+          "enum": [
+            "grimoire-browser-capture"
+          ]
+        },
+        "protocol_version": {
+          "type": "integer",
+          "description": "Browser integration protocol version",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "grimoire_version": {
+          "type": "string",
+          "description": "Daemon package version"
+        },
+        "endpoints": {
+          "type": "object",
+          "properties": {
+            "capture": {
+              "type": "string",
+              "description": "Authenticated bookmark capture path"
+            },
+            "taxonomy": {
+              "type": "string",
+              "description": "Authenticated category and tag discovery path"
+            }
+          },
+          "required": [
+            "capture",
+            "taxonomy"
+          ],
+          "additionalProperties": false
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "request_bytes": {
+              "type": "integer",
+              "description": "Maximum capture request bytes",
+              "minimum": 1
+            },
+            "title_characters": {
+              "type": "integer",
+              "description": "Maximum title characters",
+              "minimum": 1
+            },
+            "notes_characters": {
+              "type": "integer",
+              "description": "Maximum notes characters",
+              "minimum": 1
+            },
+            "selected_text_characters": {
+              "type": "integer",
+              "description": "Maximum selected text characters",
+              "minimum": 1
+            },
+            "tag_characters": {
+              "type": "integer",
+              "description": "Maximum characters per tag",
+              "minimum": 1
+            }
+          },
+          "required": [
+            "request_bytes",
+            "title_characters",
+            "notes_characters",
+            "selected_text_characters",
+            "tag_characters"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "protocol",
+        "protocol_version",
+        "grimoire_version",
+        "endpoints",
+        "limits"
+      ],
+      "additionalProperties": false,
+      "description": "Authenticated capabilities advertised to packaged browser extensions"
+    },
+    "BrowserIntegrationCapabilitiesResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "ref": "BrowserIntegrationCapabilities"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "additionalProperties": false,
+      "description": "Browser integration capability response"
+    },
+    "BrowserIntegrationTaxonomy": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "description": "Category tree",
+          "items": {
+            "ref": "CategoryNode"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "description": "Tags",
+          "items": {
+            "ref": "TagWithCount"
+          }
+        }
+      },
+      "required": [
+        "categories",
+        "tags"
+      ],
+      "additionalProperties": false,
+      "description": "Authenticated taxonomy subset used by the browser extension"
+    },
+    "BrowserIntegrationTaxonomyResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "ref": "BrowserIntegrationTaxonomy"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "additionalProperties": false,
+      "description": "Browser integration taxonomy response"
+    },
     "Diagnostics": {
       "type": "object",
       "properties": {
@@ -9253,6 +9391,58 @@
           }
         }
       ]
+    },
+    {
+      "method": "GET",
+      "path": "/integrations/browser/v1/capabilities",
+      "tag": "Integrations",
+      "summary": "Negotiate the packaged browser extension capture protocol.",
+      "description": "Requires a managed integration bearer token. Packaged Chrome and Firefox clients use this endpoint to distinguish current Grimoire from the legacy account API before sending capture data. The response describes stable paths and enforced field limits; clients must not infer compatibility from the daemon marketing version alone.",
+      "responses": {
+        "200": {
+          "description": "Supported browser integration capabilities",
+          "contentType": "application/json",
+          "schema": {
+            "ref": "BrowserIntegrationCapabilitiesResponse"
+          }
+        },
+        "401": {
+          "description": "Missing, invalid, rotated, or revoked integration token",
+          "contentType": "application/problem+json",
+          "schema": {
+            "ref": "ProblemDetails"
+          }
+        }
+      },
+      "examples": [
+        {
+          "title": "Negotiate browser capture support",
+          "request": "curl http://127.0.0.1:3210/integrations/browser/v1/capabilities \\\n  -H \"Authorization: Bearer limp_it_example\""
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/integrations/browser/v1/taxonomy",
+      "tag": "Integrations",
+      "summary": "List the categories and tags available to the packaged browser extension.",
+      "description": "Requires a managed integration bearer token. This route keeps extension-origin reads inside the versioned browser integration surface instead of exposing unrelated local-library GET routes.",
+      "responses": {
+        "200": {
+          "description": "Browser capture categories and tags",
+          "contentType": "application/json",
+          "schema": {
+            "ref": "BrowserIntegrationTaxonomyResponse"
+          }
+        },
+        "401": {
+          "description": "Missing, invalid, rotated, or revoked integration token",
+          "contentType": "application/problem+json",
+          "schema": {
+            "ref": "ProblemDetails"
+          }
+        }
+      }
     },
     {
       "method": "GET",

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -947,6 +947,14 @@
           "maxLength": 100000,
           "nullable": true
         },
+        "is_pinned": {
+          "type": "boolean",
+          "description": "Whether the new bookmark should be pinned"
+        },
+        "read_later": {
+          "type": "boolean",
+          "description": "Whether the new bookmark should be added to Read Later"
+        },
         "source": {
           "ref": "CaptureSource"
         }
@@ -4948,6 +4956,25 @@
             "taxonomy"
           ],
           "additionalProperties": false
+        },
+        "capture_fields": {
+          "type": "object",
+          "properties": {
+            "is_pinned": {
+              "type": "boolean",
+              "description": "Capture accepts an initial pinned state"
+            },
+            "read_later": {
+              "type": "boolean",
+              "description": "Capture accepts an initial Read Later state"
+            }
+          },
+          "required": [
+            "is_pinned",
+            "read_later"
+          ],
+          "additionalProperties": false,
+          "description": "Optional capture fields supported by this daemon"
         },
         "limits": {
           "type": "object",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3882,6 +3882,72 @@
         "x-grimoire-source-method": "POST"
       }
     },
+    "/integrations/browser/v1/capabilities": {
+      "get": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Negotiate the packaged browser extension capture protocol.",
+        "description": "Requires a managed integration bearer token. Packaged Chrome and Firefox clients use this endpoint to distinguish current Grimoire from the legacy account API before sending capture data. The response describes stable paths and enforced field limits; clients must not infer compatibility from the daemon marketing version alone.",
+        "operationId": "getIntegrationsBrowserV1Capabilities",
+        "responses": {
+          "200": {
+            "description": "Supported browser integration capabilities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowserIntegrationCapabilitiesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing, invalid, rotated, or revoked integration token",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-grimoire-source-method": "GET"
+      }
+    },
+    "/integrations/browser/v1/taxonomy": {
+      "get": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "List the categories and tags available to the packaged browser extension.",
+        "description": "Requires a managed integration bearer token. This route keeps extension-origin reads inside the versioned browser integration surface instead of exposing unrelated local-library GET routes.",
+        "operationId": "getIntegrationsBrowserV1Taxonomy",
+        "responses": {
+          "200": {
+            "description": "Browser capture categories and tags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowserIntegrationTaxonomyResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing, invalid, rotated, or revoked integration token",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-grimoire-source-method": "GET"
+      }
+    },
     "/capture/bookmarklet": {
       "get": {
         "tags": [
@@ -9091,6 +9157,144 @@
           "version",
           "uptime",
           "queueSize"
+        ],
+        "additionalProperties": false
+      },
+      "BrowserIntegrationCapabilities": {
+        "type": "object",
+        "description": "Authenticated capabilities advertised to packaged browser extensions",
+        "properties": {
+          "protocol": {
+            "type": "string",
+            "description": "Stable browser integration protocol identifier",
+            "enum": [
+              "grimoire-browser-capture"
+            ]
+          },
+          "protocol_version": {
+            "type": "integer",
+            "description": "Browser integration protocol version",
+            "minimum": 1,
+            "maximum": 1
+          },
+          "grimoire_version": {
+            "type": "string",
+            "description": "Daemon package version"
+          },
+          "endpoints": {
+            "type": "object",
+            "properties": {
+              "capture": {
+                "type": "string",
+                "description": "Authenticated bookmark capture path"
+              },
+              "taxonomy": {
+                "type": "string",
+                "description": "Authenticated category and tag discovery path"
+              }
+            },
+            "required": [
+              "capture",
+              "taxonomy"
+            ],
+            "additionalProperties": false
+          },
+          "limits": {
+            "type": "object",
+            "properties": {
+              "request_bytes": {
+                "type": "integer",
+                "description": "Maximum capture request bytes",
+                "minimum": 1
+              },
+              "title_characters": {
+                "type": "integer",
+                "description": "Maximum title characters",
+                "minimum": 1
+              },
+              "notes_characters": {
+                "type": "integer",
+                "description": "Maximum notes characters",
+                "minimum": 1
+              },
+              "selected_text_characters": {
+                "type": "integer",
+                "description": "Maximum selected text characters",
+                "minimum": 1
+              },
+              "tag_characters": {
+                "type": "integer",
+                "description": "Maximum characters per tag",
+                "minimum": 1
+              }
+            },
+            "required": [
+              "request_bytes",
+              "title_characters",
+              "notes_characters",
+              "selected_text_characters",
+              "tag_characters"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "protocol",
+          "protocol_version",
+          "grimoire_version",
+          "endpoints",
+          "limits"
+        ],
+        "additionalProperties": false
+      },
+      "BrowserIntegrationCapabilitiesResponse": {
+        "type": "object",
+        "description": "Browser integration capability response",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/BrowserIntegrationCapabilities"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "additionalProperties": false
+      },
+      "BrowserIntegrationTaxonomy": {
+        "type": "object",
+        "description": "Authenticated taxonomy subset used by the browser extension",
+        "properties": {
+          "categories": {
+            "type": "array",
+            "description": "Category tree",
+            "items": {
+              "$ref": "#/components/schemas/CategoryNode"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "description": "Tags",
+            "items": {
+              "$ref": "#/components/schemas/TagWithCount"
+            }
+          }
+        },
+        "required": [
+          "categories",
+          "tags"
+        ],
+        "additionalProperties": false
+      },
+      "BrowserIntegrationTaxonomyResponse": {
+        "type": "object",
+        "description": "Browser integration taxonomy response",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/BrowserIntegrationTaxonomy"
+          }
+        },
+        "required": [
+          "data"
         ],
         "additionalProperties": false
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5210,6 +5210,14 @@
             "maxLength": 100000,
             "nullable": true
           },
+          "is_pinned": {
+            "type": "boolean",
+            "description": "Whether the new bookmark should be pinned"
+          },
+          "read_later": {
+            "type": "boolean",
+            "description": "Whether the new bookmark should be added to Read Later"
+          },
           "source": {
             "$ref": "#/components/schemas/CaptureSource"
           }
@@ -9196,6 +9204,25 @@
             "required": [
               "capture",
               "taxonomy"
+            ],
+            "additionalProperties": false
+          },
+          "capture_fields": {
+            "type": "object",
+            "description": "Optional capture fields supported by this daemon",
+            "properties": {
+              "is_pinned": {
+                "type": "boolean",
+                "description": "Capture accepts an initial pinned state"
+              },
+              "read_later": {
+                "type": "boolean",
+                "description": "Capture accepts an initial Read Later state"
+              }
+            },
+            "required": [
+              "is_pinned",
+              "read_later"
             ],
             "additionalProperties": false
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grimoire",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grimoire",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "author": "Robert Goniszewski",
   "repository": {

--- a/scripts/api-docs-generator.test.ts
+++ b/scripts/api-docs-generator.test.ts
@@ -269,7 +269,7 @@ describe("API documentation generator", () => {
     expect(markdown).toContain("Content-Type: application/json");
   });
 
-  it("documents common local-client error flows without extension or bookmarklet examples", () => {
+  it("documents common local-client error flows without extension or bookmarklet error examples", () => {
     const document = buildApiContractDocument(apiContract);
     const markdown = buildApiMarkdown(document);
     const problemExamples = document.routes.flatMap((route) =>
@@ -285,7 +285,6 @@ describe("API documentation generator", () => {
     );
     expect(markdown).toContain('"type": "https://littleimp.app/problems/unprocessable-entity"');
     expect(markdown).toContain('WWW-Authenticate: Bearer realm="littleimp-local-integrations"');
-    expect(markdown).not.toMatch(/browser extension/i);
     // The bookmarklet endpoint is documented but must not appear in error-flow example titles
     expect(problemExamples.map((example) => example.title)).not.toEqual(
       expect.arrayContaining(["bookmarklet"])
@@ -300,7 +299,6 @@ describe("API documentation generator", () => {
     expect(markdown).toContain("http://localhost:5173");
     expect(markdown).toContain("http://127.0.0.1:3210");
     expect(markdown).toContain("Non-loopback origins are ignored");
-    expect(markdown).not.toMatch(/browser extension/i);
     // The bookmarklet endpoint appears in the route table but not in the CORS setup prose
     expect(markdown).toContain("/capture/bookmarklet");
   });

--- a/scripts/homebrew-formula.test.ts
+++ b/scripts/homebrew-formula.test.ts
@@ -41,6 +41,10 @@ const releaseChecksumBaselines: Record<string, ReleaseChecksumBaseline> = {
     macos: "c68bc963602a79631c76df223b9cc4a3709a0d382c0b117288f27c72da96c88f",
     linux: "50429c64e2befeca1daca6d44a95d74f755f7be4a16ed869d68a80007809d340",
   },
+  "1.2.0": {
+    macos: "3f67b1d94ca59170eedcfc398923afd1c8b9e2f9770b77f72ceccfe3e16b459f",
+    linux: "00bbbbba2baab973db4084c72d2c7f78f5b93b6b8adf63176c62a9066905c698",
+  },
 };
 
 function packageVersion(): string {

--- a/src/pages/Settings.test.tsx
+++ b/src/pages/Settings.test.tsx
@@ -57,6 +57,7 @@ const mockedCheckHealthAfterRestore = (api as unknown as { checkHealthAfterResto
 const mockedGetDiagnostics = (api as unknown as { getDiagnostics: ReturnType<typeof vi.fn> }).getDiagnostics;
 const mockedReprocessBookmarks = (api as unknown as { reprocessBookmarks: ReturnType<typeof vi.fn> }).reprocessBookmarks;
 const mockedGetReprocessStatus = (api as unknown as { getReprocessStatus: ReturnType<typeof vi.fn> }).getReprocessStatus;
+const mockedListIntegrationTokens = (api as unknown as { listIntegrationTokens: ReturnType<typeof vi.fn> }).listIntegrationTokens;
 const mockedUseBackupList = backupHooks.useBackupList as unknown as ReturnType<typeof vi.fn>;
 const mockedUseCreateBackup = backupHooks.useCreateBackup as unknown as ReturnType<typeof vi.fn>;
 const mockedUseRestoreBackup = backupHooks.useRestoreBackup as unknown as ReturnType<typeof vi.fn>;
@@ -230,6 +231,7 @@ beforeEach(() => {
       failed: 0,
     },
   });
+  mockedListIntegrationTokens.mockResolvedValue({ data: [] });
   mockedUseBackupList.mockReturnValue({
     data: [
       {
@@ -261,6 +263,20 @@ beforeEach(() => {
   mockedUseCreateEncryptedBackupPackage.mockReturnValue({ mutate: vi.fn(), isPending: false });
   mockedUseVerifyEncryptedBackupPackage.mockReturnValue({ mutate: vi.fn(), isPending: false });
   mockedUseRestoreEncryptedBackupPackage.mockReturnValue({ mutate: vi.fn(), isPending: false });
+});
+
+describe("Browser Integration guidance", () => {
+  it("explains that integration tokens authenticate every supported local client", async () => {
+    render(<Settings />, { wrapper: makeWrapper() });
+
+    expect(await screen.findByText("Browser Integration")).toBeInTheDocument();
+    expect(screen.getByText(/official browser extension, bookmarklets, MCP clients/)).toBeInTheDocument();
+    expect(screen.getByText(/Create one for the official browser extension, a bookmarklet, an MCP client/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Setup guide" }));
+    expect(screen.getByText("Using integration tokens")).toBeInTheDocument();
+    expect(screen.getByText(/paste the token into its connection screen/)).toBeInTheDocument();
+  });
 });
 
 describe("Settings update checks", () => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -2284,7 +2284,8 @@ function BrowserIntegration() {
         <div>
           <h2 className="text-sm font-semibold">Browser Integration</h2>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Create an integration token and install the bookmarklet to save pages from any browser.
+            Integration tokens authenticate the official browser extension, bookmarklets, MCP clients,
+            and other supported local integrations. Create a separate token for each client so you can revoke access independently.
           </p>
         </div>
         <Button
@@ -2301,24 +2302,25 @@ function BrowserIntegration() {
       {/* Setup instructions */}
       {showInstructions && (
         <div className="rounded border px-4 py-3 text-xs bg-muted/30 space-y-2">
-          <p className="font-medium text-sm">Installing the bookmarklet</p>
+          <p className="font-medium text-sm">Using integration tokens</p>
           <ol className="list-decimal list-inside space-y-1 text-muted-foreground">
-            <li>Create a new integration token below. Existing token rows only expose a prefix and cannot generate a bookmarklet.</li>
+            <li>Create a new token below and name it after the browser, extension, or integration that will use it.</li>
             <li>Copy the full token shown after creation — it is only displayed once.</li>
-            <li>While the new token is still available, click its "Bookmarklet" button or use the copy link in the token-created message.</li>
+            <li>For the official Grimoire browser extension, paste the token into its connection screen.</li>
+            <li>For a bookmarklet, click the new token's "Bookmarklet" button or use the copy link in the token-created message.</li>
             <li>Paste the bookmarklet code into a browser bookmark's URL field, or drag the link to your bookmarks bar.</li>
             <li>When clicked, the bookmarklet opens a short-lived Grimoire capture window. Allow popups for the page if your browser blocks it.</li>
             <li>Replace bookmarklets created by older Grimoire versions — create a new token because the old full secret cannot be recovered.</li>
           </ol>
-          <p className="font-medium text-sm mt-3">Browser notes</p>
+          <p className="font-medium text-sm mt-3">Bookmarklet browser notes</p>
           <ul className="list-disc list-inside space-y-1 text-muted-foreground">
             <li><strong>Chrome / Edge:</strong> Show the bookmarks bar (Ctrl+Shift+B / Cmd+Shift+B), then drag the bookmarklet link onto it.</li>
             <li><strong>Firefox:</strong> Right-click the bookmarks bar and choose "Add Bookmark". Paste the bookmarklet code as the URL.</li>
             <li><strong>Safari:</strong> Show the Favorites bar (View → Show Favorites Bar), then drag the bookmarklet link onto it.</li>
           </ul>
           <div className="rounded bg-warning/10 border border-warning/30 px-3 py-2 text-warning">
-            <strong>Security note:</strong> The bookmarklet embeds your integration token. Anyone with access to
-            your browser bookmarks can capture pages to your Grimoire library. Treat it like a password.
+            <strong>Security note:</strong> Treat every integration token like a password. Anyone who obtains one can
+            use the local integration surfaces it authenticates. A bookmarklet embeds its token in your browser bookmarks.
           </div>
         </div>
       )}
@@ -2350,7 +2352,7 @@ function BrowserIntegration() {
               </Button>
             </div>
             <p className="text-xs mt-1">
-              Then{" "}
+              Paste the token into the official browser extension or another supported integration. For a bookmarklet, {" "}
               <button
                 className="text-primary underline"
                 onClick={() => {
@@ -2418,7 +2420,7 @@ function BrowserIntegration() {
           </div>
         ) : tokens.length === 0 && !showCreate ? (
           <div className="text-xs text-muted-foreground">
-            No integration tokens yet. Create one to use the bookmarklet.
+            No integration tokens yet. Create one for the official browser extension, a bookmarklet, an MCP client, or another supported integration.
           </div>
         ) : (
           tokens.map((token) => (
@@ -2511,7 +2513,7 @@ function BrowserIntegration() {
           <AlertDialogHeader>
             <AlertDialogTitle>Revoke integration token?</AlertDialogTitle>
             <AlertDialogDescription>
-              Bookmarks saved with this token in browser bookmarklets will stop working.
+              Any browser extension, bookmarklet, MCP client, or other integration using this token will stop working.
               This cannot be undone. Create a new token to replace it.
             </AlertDialogDescription>
           </AlertDialogHeader>


### PR DESCRIPTION
The rewritten Grimoire Companion could not safely use the current daemon: extension-origin writes were rejected, general taxonomy routes were outside a dedicated authenticated boundary, and there was no stable capability handshake. This adds a versioned browser-integration protocol with authenticated capability and taxonomy endpoints, permits packaged Chrome and Firefox origins only on the three required routes, and explicitly rejects extension-origin access to unrelated daemon reads and writes.

The companion can now negotiate protocol v1, load categories and tags through its bearer token, and submit a normal `/capture` request without broadening Grimoire beyond loopback. The generated API contract and browser-capture guidance are updated.

Validation:
- `bun test daemon/src/test/integration/browser-integration.test.ts daemon/src/test/integration/capture.test.ts daemon/src/test/integration/integration-token-auth.test.ts daemon/src/test/integration/security-hardening.test.ts` (28 passed, 129 assertions)
- `npm run lint` (no errors; 8 existing Fast Refresh warnings)
- `npm run type-check`
- `npm run docs:api:check`
- packaged Chrome Companion smoke covering negotiation, authenticated taxonomy, capture persistence, and category/tag/notes mapping
